### PR TITLE
Add v0.3 change spec adapted from whatisverdezul.com findings

### DIFF
--- a/docs/specs/v0.3-plan.md
+++ b/docs/specs/v0.3-plan.md
@@ -1,0 +1,196 @@
+# Ryder v0.3 — phased execution plan
+
+The work queue for [issue #53](https://github.com/arts-link/ryder/issues/53).
+The design record — evidence, rationale, and code excerpts for every item — is
+[v0.3.md](./v0.3.md); this file only orders the work and defines the exit gate
+for each phase. Item numbers (1.1, 2.6, …) refer to that spec's sections.
+
+Baseline: `a95ed03` (`v0.2.3-3-ga95ed03`, current `main`).
+
+Three releases, one phase each, plus a safety-net phase first. Nothing breaking
+ships before v0.3.0, so the non-breaking majority does not wait on the breaking
+minority:
+
+| Phase | Release | Contents | Breaking |
+|---|---|---|---|
+| 0 | — (lands with v0.2.4) | 2.6, 1.9 | no |
+| 1 | v0.2.4 | Tier 1 (1.1–1.8) | no |
+| 2 | v0.2.5 | Tier 2 except 2.2; Tier 4 except 4.3; Tier 5; issue #3 font work | no |
+| 3 | v0.3.0 | 2.2, Tier 3, 4.3 | yes |
+
+---
+
+## Phase 0 — safety net first
+
+Do this before any other template work. It makes the 1.9 class of bug —
+variant dispatch resolving to a partial that does not exist — self-reporting,
+so every later variant-related change lands with a net that did not exist for
+the last one.
+
+- **2.6** Guard variant dispatch with `templates.Exists` in `baseof.html:12,25`
+  and `header.html:50`: `warnf` naming the param and the resolved partial, fall
+  back to the base variant.
+- **1.9** Correct `REWRITE.md`: delete the five stale `-fun` claims, reword the
+  Phase 5 deferral, add a note that `ea2538c` removed the variants. Correct the
+  record; do not silently rewrite it.
+
+**Exit gate:** a fixture build with a typo'd `headerType` warns and renders the
+base header instead of failing cryptically; `REWRITE.md` no longer describes
+files that do not exist.
+
+## Phase 1 — v0.2.4: Tier 1 defects
+
+All in [Tier 1](./v0.3.md#tier-1--silent-failures-and-defects). None breaking.
+
+- **1.1** Document the `[security.funcs] getenv` requirement (README + a
+  build-time warning when `PUBLIC_POSTHOG_*` are set but unreadable); lead docs
+  with the `posthog_key` / `posthog_host` params. Files: `README.md`,
+  `layouts/partials/posthog.html`, `exampleSite` config.
+- **1.2** Remove the three JS comments inside JSON-LD
+  (`head/schema.html:5,45,105`). Structural fix comes in 2.2; this is the
+  minimal defect fix.
+- **1.3** OG resolver: normalize the leading slash, guard with `with`, `errorf`
+  naming the offending param. Reuse the `header.html:22-26` normalization
+  pattern. File: `common-partials/opengraph/get-featured-image.html:7-9`.
+  Document `og_image_default` as `assets/`-only.
+- **1.4** Guard `footer.html:9` (`.Param "footer.tagCloud"` or `with`).
+- **1.5** Add `params.darkMode` (`"toggle"` / `"system"` / `"off"`) with the
+  compatibility mapping from the spec — unset resolves to `"system"`,
+  `showDarkToggle = true` to `"toggle"`, so every existing site renders
+  identically until it opts in. Fix the README/`exampleSite` claim that
+  `showDarkToggle` defaults true (`head/js.html:3` defaults it false).
+  Files: `assets/js/themeBoot.js`, `layouts/partials/head.html`,
+  `head/js.html`, `_default/baseof.html`.
+- **1.6** CSP `frame-src`: embed shortcodes register hosts on `.Store`,
+  `head/csp.html` folds them in; add `params.csp.embeds` preset; add the
+  missing uMap host to `exampleSite`; document `frameSrc`.
+- **1.7** Declare the runtime JS deps in the theme's `package.json`
+  `dependencies` (documentation + theme dev loop); README states the required
+  root-level install explicitly; `head/js.html` gains a legible `errorf` for
+  missing packages.
+- **1.8** Move `[build] writeStats` and the three `[[build.cachebusters]]`
+  rules from `exampleSite` config into the theme's own `hugo.toml` so consumers
+  inherit them.
+
+**Exit gate:** spec [Verification](./v0.3.md#verification) checks 1, 3, 5, 6, 7
+pass (JSON-LD parses via `jq`; getenv misconfiguration warns; `darkMode = "off"`
+yields no `dark` class under Playwright `colorScheme: 'dark'`; fixture with no
+`[params.footer]`/`[params.csp]` builds; bad `og_image_default` produces a named
+`errorf`). Release: annotated tag `v0.2.4`, `theme.toml` version bumped in the
+same commit, `CHANGELOG.md` started.
+
+## Phase 2 — v0.2.5: extension points, CSP-safe Alpine, primitives
+
+[Tier 2](./v0.3.md#tier-2--missing-extension-points) except 2.2;
+[Tier 4](./v0.3.md#tier-4--csp-safe-alpine) except 4.3;
+[Tier 5](./v0.3.md#tier-5--missing-primitives). All additive.
+
+Extension points:
+
+- **2.1** `_default/list-plain.html` (title + `.Content`, no feed) selectable
+  via `listType`; ship `partials/utils/data-items.html` returning partial for
+  the empty-data idiom.
+- **2.3** Widen the OG image chain: `og_image` front matter →
+  `og_image_default` → page-bundle resources → generator.
+- **2.4** Menu `showIf` / `hideIfEmptyData` param honored in `menu.html`.
+- **2.5** Honor `navClass` / `headerClass` `.Param` in the base header;
+  document the "one variant plus `.Param` for the skin" pattern.
+- **2.7** `twClasses.body`; stable `site-shell` hook class with
+  `position: relative` on the `baseof.html:10` wrapper; move
+  `tw-size-indicator` inside the wrapper.
+- **Issue #3 (partial)** While 2.7 is open, fold in the font work: `params.fonts`
+  covering `head/fonts.html` and the `main.css:157` `font-family`; 2.7 and 3.1
+  remove the other two hardcoded Titillium sites.
+
+CSP-safe Alpine:
+
+- **4.1** `Alpine.data('ryderTrack')` in `main.js` (port from the site's
+  `extended.js:69-77`, generalized past PostHog).
+- **4.2** `Alpine.data('ryderForm')` (port from `extended.js:10-64`); README
+  note that the action host needs `params.csp.connectSrc`.
+- **4.4** Dev-only `assets/js/cspLint.js` warning on inline directives
+  containing `(` or `=>`, loaded only when `hugo.Environment == "development"`.
+- **4.5** README section: the `@alpinejs/csp` restriction, both primitives, and
+  the `assets/js/extended.js` escape hatch (currently documented nowhere).
+
+Primitives (Tier 5):
+
+- **5.1** `youtube` and `spotify` shortcodes.
+- **5.2** Video lightbox beside the image one.
+- **5.3** `utils/socialslist.html` accepts both social data shapes; inline SVGs
+  for the common music platforms rather than widening the Font Awesome bundle.
+- **5.4** `logo_wrapperClass` param or drop the wrapper chrome when `logo_png`
+  is set; settle the `.Param` vs `.Site.Params` contract for `logo_png`.
+- **5.5** Parameterize `head/favicon.html`; apple-touch-icon + webmanifest.
+- **5.6** Make `showHomeFeed` honored (or a selectable non-blog home layout).
+
+**Exit gate:** spec Verification checks 2 and 4 pass (zero CSP violations on
+the leaflet and media-embeds `exampleSite` pages in Chromium; Playwright
+`ryderTrack` test asserting `capture` receives the right event and props — the
+regression test the three production outages never had). `exampleSite` updated
+to exercise each new param/primitive. Watch the 2.7 risk called out in the
+spec's migration section: the new containing block and DOM move can shift
+absolutely-positioned descendants and break `body > div` selectors. Release:
+annotated tag `v0.2.5`, `theme.toml` bump, CHANGELOG entry.
+
+## Phase 3 — v0.3.0: the breaking changes
+
+Four breaking changes: 2.2, [Tier 3](./v0.3.md#tier-3--packaging-and-build),
+and 4.3. Prerequisite: merge Dependabot PRs #51/#52 **before** 3.1 — they touch
+npm groups Tier 3 reorganizes.
+
+- **2.2** Rewrite `head/schema.html` to build `dict`s + `jsonify` (the site's
+  override is the reference implementation); add a no-op `head/schema-extra.html`
+  seam called from `head-seo.html`; add `params.schema.type`; fix the mixed
+  homepage tests, `articleBody` inlining, and comma-dependent `"email"` in
+  passing. Document `extend_head.html`.
+- **3.1** Ship `tailwind.preset.js` (`theme`, `darkMode`, `plugins` — no
+  `content`); `tailwind.config.js` becomes a thin dev-loop wrapper; document
+  the consumer `presets: [...]` pattern.
+- **3.2** Delete `assets/css/style.css` (125 KB committed artifact, zero
+  references).
+- **3.3** Delete the `build-tw` / `watch-tw` / `deploy-tw` scripts; rewrite the
+  README build section with the real requirement (root-level `tailwindcss`,
+  `postcss`, `postcss-cli`, `autoprefixer` + `postcss.config.js`; then
+  `hugo server` alone suffices).
+- **3.4** README note that the theme's `[outputs]` config merges into the
+  site's, so consumers must not duplicate it.
+- **4.3** Build the PostHog snippet with
+  `resources.FromString | js.Build | fingerprint`, load via `src` + `integrity`,
+  stop appending `'unsafe-inline'`; add `params.csp.scriptSrcHashes` (the
+  Plausible hash pattern at `head/csp.html:43-44` already does this in-house).
+
+**Exit gate:** spec Verification check 8 passes (clean consumer clone,
+`npm install` at project root only, `hugo --minify` succeeds). Deliverables
+beyond code: `docs/migration/v0.3.0.md` (consumer-facing version of the spec's
+migration section), CHANGELOG entry with a `### Breaking` heading linking each
+item, annotated tag `v0.3.0`, `theme.toml` bump. Audit the author's other Ryder
+sites for `*-tw` / `style.css` reliance before publishing the tag.
+
+---
+
+## Cross-cutting release discipline
+
+From the spec's [What the theme owes consumers](./v0.3.md#what-the-theme-owes-consumers),
+applied at every phase:
+
+- Annotated tags, cut from the commit that bumps `theme.toml` — consumers pin
+  tags, not tips.
+- `CHANGELOG.md` entry per release, `### Breaking` heading where applicable,
+  entries linking spec item numbers.
+- `exampleSite` updated alongside every change, so it stays the reference
+  implementation a migrating site can diff against.
+- Upgrade guidance stays one-release-at-a-time:
+  `v0.2.3 → v0.2.4 → v0.2.5 → v0.3.0`, per the spec's
+  [migration path](./v0.3.md#migration-path-for-existing-ryder-sites) — and the
+  stale-override audit there matters more than any individual item.
+
+## Success metric
+
+Not the feature list — the deletion list. After v0.3.0, re-point
+whatisverdezul.com's submodule, run `hugo --minify`, and confirm it can delete
+its overrides (favicon, OG resolver, `!important` body block, the
+`body:has(…) > div:not(.fixed)` hack, `vzTrack` + ten workaround comments, three
+header variants, `scriptSrc = "'unsafe-inline'"`, dead config, `tw-built.css`,
+the `*-tw` scripts) with rendered output unchanged. The full list is in the
+spec's [Verification section](./v0.3.md#the-real-success-metric).

--- a/docs/specs/v0.3-plan.md
+++ b/docs/specs/v0.3-plan.md
@@ -5,29 +5,52 @@ The design record — evidence, rationale, and code excerpts for every item — 
 [v0.3.md](./v0.3.md); this file only orders the work and defines the exit gate
 for each phase. Item numbers (1.1, 2.6, …) refer to that spec's sections.
 
-Baseline: `a95ed03` (`v0.2.3-3-ga95ed03`, current `main`).
+Baseline: `a95ed03` (`v0.2.3-3-ga95ed03`), the commit this plan was written
+against.
 
 Three releases, one phase each, plus a safety-net phase first. Nothing breaking
 ships before v0.3.0, so the non-breaking majority does not wait on the breaking
 minority:
 
-| Phase | Release | Contents | Breaking |
-|---|---|---|---|
-| D | — (no release) | merge the 5 open Dependabot PRs | no |
-| 0 | — (lands with v0.2.4) | 2.6, 1.9 | no |
-| 1 | v0.2.4 | Tier 1 (1.1–1.8) | no |
-| 2 | v0.2.5 | Tier 2 except 2.2; Tier 4 except 4.3; Tier 5; issue #3 font work | no |
-| 3 | v0.3.0 | 2.2, Tier 3, 4.3 | yes |
+| Phase | Release | Contents | Breaking | Status |
+|---|---|---|---|---|
+| D | — (no release) | Dependabot backlog | no | **Done** — 9 PRs merged; vulnerabilities 18 → 10, criticals 2 → 0 |
+| 0 | — (shipped in v0.2.4) | 2.6, 1.9 | no | **Done** — [#60](https://github.com/arts-link/ryder/pull/60) |
+| 1 | v0.2.4 | Tier 1 (1.1–1.8) | no | **Done** — [#62](https://github.com/arts-link/ryder/pull/62), released [v0.2.4](https://github.com/arts-link/ryder/releases/tag/v0.2.4) |
+| 2 | v0.2.5 | Tier 2 except 2.2; Tier 4 except 4.3; Tier 5; issue #3 font work | no | Next |
+| 3 | v0.3.0 | 2.2, Tier 3, 4.3 | yes | Not started |
+
+Release hygiene fixed alongside Phase 1, in
+[#63](https://github.com/arts-link/ryder/pull/63): the release workflow had
+hardcoded `prerelease=true`, which hid every automated release from the repo's
+"Latest release" badge. It now derives that flag from the version, sources
+release notes from `CHANGELOG.md`, and cuts annotated tags — three of the items
+the spec's *What the theme owes consumers* section asks for.
 
 ---
 
-## Phase D — dependency PRs (can start immediately)
+## Phase D — dependency PRs — **complete**
 
-Independent of everything else, and worth doing first: GitHub reports 18
+Independent of everything else, and worth doing first: GitHub reported 18
 Dependabot vulnerabilities (2 critical, 10 high) on the default branch, and the
 spec already requires #51/#52 to land before 3.1 reorganizes the npm groups.
 
-CI state as of 2026-07-26:
+**Outcome.** Merged #46, #47, #51, #55, #56, #57, #58, #59, #61 — vulnerabilities
+down to 10 with both criticals cleared. Two findings worth carrying forward:
+
+- **Tailwind is pinned to v3 deliberately** ([#55](https://github.com/arts-link/ryder/pull/55)).
+  #52 failed E2E because its group bump took `exampleSite` to Tailwind v4, whose
+  PostCSS plugin moved to `@tailwindcss/postcss`, so `hugo server` never started.
+  #51 had quietly done the same to the root `package.json` — CI missed it because
+  nothing CI runs uses the root Tailwind install. Dependabot now ignores Tailwind
+  majors in both npm ecosystems; a v4 migration is its own project, outside this
+  spec.
+- **Do not use `update-branch` on a Dependabot PR.** Doing so puts a
+  non-Dependabot commit on its branch, after which Dependabot refuses to rebase
+  or recreate it. #48 was lost that way and had to be re-applied by hand as
+  [#61](https://github.com/arts-link/ryder/pull/61). Use `@dependabot recreate`.
+
+Original CI state, 2026-07-26:
 
 | PR | Bump | Checks |
 |---|---|---|
@@ -57,7 +80,7 @@ deferred), default-branch CI green, Dependabot alert count visibly down.
 
 ---
 
-## Phase 0 — safety net first
+## Phase 0 — safety net first — **complete** ([#60](https://github.com/arts-link/ryder/pull/60))
 
 Do this before any other template work. It makes the 1.9 class of bug —
 variant dispatch resolving to a partial that does not exist — self-reporting,
@@ -75,7 +98,19 @@ the last one.
 base header instead of failing cryptically; `REWRITE.md` no longer describes
 files that do not exist.
 
-## Phase 1 — v0.2.4: Tier 1 defects
+## Phase 1 — v0.2.4: Tier 1 defects — **complete** ([#62](https://github.com/arts-link/ryder/pull/62))
+
+Two things the spec did not anticipate, both worth knowing before Phase 2:
+
+- **A blocked `getenv` does not return `""` — it fails the whole build.** Item
+  1.1 assumed silent emptiness. Every PostHog `getenv` call is now wrapped in
+  Hugo's `try` builtin, which is also what lets the warning distinguish
+  *blocked by policy* from *genuinely unset*.
+- **`exampleSite` cannot build without extended Hugo**, because its own OG image
+  is WebP — despite the theme's `hugo.toml` declaring
+  `[module.hugoVersion] extended = false`. Documented in the README's
+  Requirements section; the module flag was left alone.
+
 
 All in [Tier 1](./v0.3.md#tier-1--silent-failures-and-defects). None breaking.
 

--- a/docs/specs/v0.3-plan.md
+++ b/docs/specs/v0.3-plan.md
@@ -13,10 +13,47 @@ minority:
 
 | Phase | Release | Contents | Breaking |
 |---|---|---|---|
+| D | — (no release) | merge the 5 open Dependabot PRs | no |
 | 0 | — (lands with v0.2.4) | 2.6, 1.9 | no |
 | 1 | v0.2.4 | Tier 1 (1.1–1.8) | no |
 | 2 | v0.2.5 | Tier 2 except 2.2; Tier 4 except 4.3; Tier 5; issue #3 font work | no |
 | 3 | v0.3.0 | 2.2, Tier 3, 4.3 | yes |
+
+---
+
+## Phase D — dependency PRs (can start immediately)
+
+Independent of everything else, and worth doing first: GitHub reports 18
+Dependabot vulnerabilities (2 critical, 10 high) on the default branch, and the
+spec already requires #51/#52 to land before 3.1 reorganizes the npm groups.
+
+CI state as of 2026-07-26:
+
+| PR | Bump | Checks |
+|---|---|---|
+| #46 | `actions/checkout` 4 → 6 | Unit + E2E green |
+| #47 | `actions/upload-pages-artifact` 3 → 4 | Unit + E2E green; `claude-review` failed |
+| #48 | `actions/setup-node` 4 → 6 | Unit + E2E green; `claude-review` failed |
+| #51 | npm dev-dependencies group, 5 updates | Unit + E2E green |
+| #52 | exampleSite dependencies group, 12 updates | **E2E failed**; Unit green |
+
+Order of work:
+
+1. **Merge #46, #47, #48, #51** — tests are green. The `claude-review` failures
+   on #47/#48 completed in ~11 s, the signature of a workflow that can't run on
+   Dependabot-triggered events (secrets are withheld from them), not of a real
+   review finding. Confirm from the job log, then treat it as non-blocking —
+   and separately consider gating that workflow off `github.actor ==
+   'dependabot[bot]'` so it stops failing these PRs.
+2. **Fix #52 before merging.** Rebase it on `main` (its checks last ran
+   2026-05-14), re-run CI, and read the E2E failure. A 12-package bump to
+   `exampleSite` likely moved something Playwright looks at; if one bump is the
+   culprit, drop it from the group and take the rest. Do not merge red.
+3. Checks on all five predate the latest `main` commits — re-run against
+   current `main` before merging rather than trusting stale green.
+
+**Exit gate:** all five PRs merged (or #52's offending bump consciously
+deferred), default-branch CI green, Dependabot alert count visibly down.
 
 ---
 
@@ -184,6 +221,19 @@ applied at every phase:
   `v0.2.3 → v0.2.4 → v0.2.5 → v0.3.0`, per the spec's
   [migration path](./v0.3.md#migration-path-for-existing-ryder-sites) — and the
   stale-override audit there matters more than any individual item.
+
+## Suggested Claude Code model per phase
+
+Advisory only — match the model to how much judgment the phase demands, not to
+its size:
+
+| Phase | Model | Why |
+|---|---|---|
+| D | Haiku 4.5 (Sonnet 5 for the #52 debug) | Merges and CI-log reading are mechanical; diagnosing the E2E failure benefits from Sonnet |
+| 0 | Sonnet 5 | Two small, fully specified changes |
+| 1 | Sonnet 5 | Each defect has an exact prescribed fix in the spec; the only judgment call (1.5's default mapping) is already decided there |
+| 2 | Sonnet 5, Opus 5 for 2.7 and the Tier 4 primitives | Mostly additive template work; 2.7 carries real layout-regression risk and the Alpine primitives + Playwright tests reward stronger reasoning |
+| 3 | Opus 5 | All four breaking changes involve design judgment: the schema rewrite, the preset split, the CSP hash pipeline, and the migration doc |
 
 ## Success metric
 

--- a/docs/specs/v0.3.md
+++ b/docs/specs/v0.3.md
@@ -1,0 +1,1003 @@
+# Ryder v0.3 change spec
+
+Change spec for Ryder **v0.2.4 → v0.3.0**, written from evidence collected on
+[whatisverdezul.com](https://github.com/arts-link/whatisverdezul.com) — the
+theme's first real consumer as a git submodule. Throughout this document,
+"the site" means whatisverdezul.com.
+
+Tracked by [issue #53](https://github.com/arts-link/ryder/issues/53). Adapted
+from the original spec in the consumer repo
+([permalink](https://github.com/arts-link/whatisverdezul.com/blob/59c6981/docs/ai/specs/ryder-v0.3-spec.md)).
+The phased work queue derived from this document is
+[v0.3-plan.md](./v0.3-plan.md); this file is the design record.
+
+---
+
+## Why this spec exists
+
+The site's `hugo.toml` disables three theme features. Its `layouts/` holds 23
+files. The ones that matter are not restyled theme partials — they are wholesale
+replacements, written because the theme partial had no seam to extend or was
+outright broken. **Six of the site's seven top-level pages fork the same theme
+template** (`_default/list.html`), all for the same reason.
+
+Five theme-caused failures reached production — commits `e7bbfe1`, `d52b9cc`,
+`3d620e9`, `f71237c`, and submodule bump `70f6dcb`. Every one was **silent**: no
+build error, no console warning, correct-looking HTML.
+
+That pattern — silence — is the through-line of this spec. Most items below are
+not missing features. They are cases where Ryder fails without saying so.
+
+### How findings were verified
+
+Read against the theme at commit `a95ed03` — `v0.2.3-3-ga95ed03`, `main` at the
+time of writing, and the commit the site pins — so there is no version drift to
+reconcile. Every item cites theme file and line, and history claims are checked
+against the repo's 419 commits. Where a claim was not directly verifiable it is
+marked **PLAUSIBLE**. Citations were re-verified against this repo when the spec
+was copied here, and a handful of details corrected in place.
+
+### Release shape
+
+Ships in three pieces so the non-breaking majority does not wait on the
+breaking minority.
+
+| Release | Contents | Breaking |
+|---|---|---|
+| v0.2.4 | Tier 1 (1.1–1.9) | no |
+| v0.2.5 | Tier 2 except 2.2; Tier 4 except 4.3; Tier 5 | no |
+| v0.3.0 | 2.2, Tier 3, 4.3 | yes — see [Migration path](#migration-path-for-existing-ryder-sites) |
+
+Upgrade one release at a time. See **Migration path for existing Ryder sites**
+below for what each step changes, what breaks, and the pre-upgrade override audit
+that matters more than any individual item.
+
+---
+
+## Tier 1 — Silent failures and defects
+
+Wrong for every Ryder site, not just this one. None breaking.
+
+### 1.1 The `[security.funcs] getenv` requirement is undocumented, so PostHog silently emits nothing
+
+`posthog.html:3,7,11` and `head/csp.html:52` read `PUBLIC_POSTHOG_KEY`,
+`PUBLIC_POSTHOG_HOST`, and `PUBLIC_POSTHOG_UI_HOST` via `getenv`. Hugo's default
+allowlist is `^HUGO_` and `^CI$` only.
+
+Without an explicit `[security.funcs] getenv` entry, those calls return empty,
+`posthog.html:17` (`if and $key $apiHost`) is false, and **no analytics render at
+all** — no error, no warning. `head/csp.html:51-58` then also omits the PostHog host
+from `script-src` and `connect-src`, so even a hand-added snippet would be
+CSP-blocked.
+
+The theme README documents the three env vars and never mentions the `[security]`
+block. `exampleSite` has no `[security]` block either. The site works only
+because `hugo.toml:24-26` happens to set it.
+
+**Fix.** Add the required snippet to the README's PostHog section and to
+`exampleSite`:
+
+```toml
+[security]
+  [security.funcs]
+    getenv = ['^HUGO_', '^CI$', '^PUBLIC_']
+```
+
+Lead the docs with the allowlist-free `posthog_key` / `posthog_host` params
+instead, and treat env vars as the secondary path.
+
+### 1.2 Invalid JSON-LD — all structured data is silently discarded
+
+`head/schema.html` emits JavaScript comments *inside*
+`<script type="application/ld+json">`:
+
+- line 5 — `// homepage`
+- line 45 — `// schema for posts`
+- line 105 — `//breadcrumb schema`
+
+These are plain template text, not Hugo comments (`{{/* … */}}`), so they reach
+the output. JSON has no comment syntax, so **every affected block fails to
+parse** and the page's structured data is discarded wholesale.
+
+**Fix.** Remove them. Item 2.2 rewrites this file and eliminates the class of
+bug structurally.
+
+### 1.3 Nil-pointer build crash in the OG image resolver
+
+`common-partials/opengraph/get-featured-image.html:7-9`:
+
+```go-html-template
+{{ $customImage := .Param "og_image_default" | default "/common-partials/opengraph/opengraph-base.png" }}
+{{ $featured = resources.Get $customImage }}
+{{ $featured = $featured.Resize "1200x" }}
+```
+
+`resources.Get` returns nil for any path not under `assets/`. Two things make that
+the likely case: the theme's own default value carries a **leading slash** while
+the README and `exampleSite` both document the param *without* one
+(`og_image_default = 'images/ryder-theme-og.webp'`), and nothing normalizes
+either form. `.Resize` on nil then aborts the build with
+`nil pointer evaluating resource.Resource.Resize` — with no indication of which
+param is at fault.
+
+The site burned two commits on it: `ef5071e` put the OG images in `static/`,
+`fe6e32b` moved them to `assets/` and added `strings.TrimPrefix "/"`. The commit
+message records the lesson the theme should have stated: *"static/ files are not
+accessible via resources.Get — images must live in assets/"*.
+
+**Fix.** Normalize the leading slash, wrap the lookup in `with`, and `errorf`
+naming the offending param. `header.html:22-26` already does this normalization
+correctly — reuse that pattern:
+
+```go-html-template
+{{- with resources.Get $backgroundPath -}}{{- $backgroundPath = .RelPermalink -}}
+{{- else -}}{{- $backgroundPath = $backgroundPath | absURL -}}{{- end -}}
+```
+
+Also document `og_image_default` as `assets/`-only, since `logo_png` is documented
+as working from either `static/` or `assets/` and the inconsistency is a trap.
+
+### 1.4 `footer.html` reads an unguarded nested param
+
+`footer.html:9`:
+
+```go-html-template
+{{- if or .Site.Params.footer.tagCloud $showMiddleColumn }}
+```
+
+No `with`, no `default`. The theme's own `hugo.toml` declares no `[params]` at
+all, and only `exampleSite` sets `[params.footer]`. Any site that omits that block
+gets `can't evaluate field tagCloud in type interface {}`.
+
+It stays hidden on the site only because the footer is forked.
+
+**Fix.** Use `.Param "footer.tagCloud"`, or guard with `with`.
+
+### 1.5 Dark mode is applied to sites that turned it off
+
+`themeBoot.js:2-5` adds `dark` to `<html>` whenever `prefers-color-scheme: dark`
+matches and no `localStorage.theme` preference is stored. It never reads
+`showDarkToggle`:
+
+```js
+if (theme === 'dark' || (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+  document.documentElement.classList.add('dark')
+}
+```
+
+`head.html:4-14` loads it unconditionally. Meanwhile `showDarkToggle = false`
+reaches only `head/js.html:3`, which gates `themeSwitcher.js` — **not**
+`themeBoot.js`, and **not** `baseof.html:6`'s hardcoded
+`dark:bg-neutral-900 dark:text-neutral-100` on `<body>`.
+
+Result: an OS-dark visitor to this deliberately light band site gets a `#171717`
+body under light-designed content, with no toggle available to escape it. The
+workaround is the only `!important` in 1,569 lines of site CSS
+(`assets/css/extended/verdezul.css:836-839`):
+
+```css
+body {
+  background-color: #f5f5f5 !important;
+  color: #0a0a0a !important;
+}
+```
+
+And it is *required*: `darkMode: 'class'` compiles to `.dark .dark\:bg-neutral-900`
+at specificity (0,2,0), which beats bare `body` at (0,0,1).
+
+**Fix.** Add `params.darkMode` with values `"toggle"` / `"system"` / `"off"`. When
+`"off"`, skip `themeBoot.js` entirely and emit the body classes without `dark:`
+variants.
+
+**Get the default mapping right — the obvious version is a silent regression.**
+Deriving `darkMode` from `showDarkToggle` does not work, because
+`head/js.html:3` defaults `showDarkToggle` to **false**. Most existing sites never
+set it, so a naive mapping would resolve them to `"off"` and strip the
+system-preference dark mode that `themeBoot.js` gives them today — a visual
+change on upgrade, with nothing in the config to explain it. Use instead:
+
+| Site config | Resolved `darkMode` | Behavior vs v0.2.3 |
+|---|---|---|
+| nothing set | `"system"` | unchanged |
+| `showDarkToggle = true` | `"toggle"` | unchanged |
+| `darkMode` set explicitly | as written | opt-in |
+
+So disabling dark mode requires an explicit `darkMode = "off"`. Every existing
+site renders identically until it asks for the change.
+
+**Also fix the docs.** The README says `showDarkToggle = true # Dark mode toggle`
+and `exampleSite` comments "defaults to true", while `head/js.html:3` defaults it
+**false**. Code and docs disagree.
+
+### 1.6 The theme's own embed shortcodes are blocked by the theme's own CSP
+
+`head/csp.html:99-102` emits `frame-src` only when `params.csp.frameSrc` is set, so by
+default `default-src 'self'` blocks every iframe. But the theme ships two
+shortcodes that emit iframes — `shortcodes/soundcloud.html:14` and
+`shortcodes/openstreetmap.html:25` — as do Hugo's built-in `youtube` and `vimeo`.
+
+`exampleSite/config/_default/hugo.toml:61` patches around it:
+
+```toml
+frameSrc  = "https://www.youtube-nocookie.com https://www.youtube.com https://player.vimeo.com https://w.soundcloud.com"
+```
+
+It **omits `https://umap.openstreetmap.fr`**, so the theme's own demo of its own
+`openstreetmap` shortcode is broken in its own exampleSite. And the README never
+mentions `frameSrc` at all.
+
+**Fix.** Three parts:
+
+1. Have each embed shortcode register its host on `.Store`, and have `head/csp.html`
+   fold registered hosts into `frame-src` automatically.
+2. Add a preset for hosts the theme cannot detect:
+   `params.csp.embeds = ["youtube", "vimeo", "soundcloud", "spotify", "umap"]`.
+   The site currently hand-writes `open.spotify.com` and
+   `www.youtube-nocookie.com` at `hugo.toml:19`.
+3. Add the missing uMap host to `exampleSite`, and document `frameSrc` in the
+   README.
+
+### 1.7 The theme's runtime JS dependencies are not declared
+
+`assets/js/main.js` imports `@alpinejs/csp`, `@alpinejs/focus`,
+`@fortawesome/fontawesome-svg-core`, all three `@fortawesome/free-*-svg-icons`
+packages, and `leaflet`. **None appear in the theme's `package.json`** — they are
+declared only in `exampleSite/package.json`.
+
+A consuming site's `js.Build` therefore fails until the site reverse-engineers
+the import list out of `main.js`. That is exactly why the site's repo carries all
+six in its own `devDependencies` *plus*:
+
+```json
+"postinstall": "cd themes/ryder && npm install"
+```
+
+**Fix.** Three parts, and note the important limitation in the middle one:
+
+1. Declare them in the theme's `package.json` `dependencies`, so the authoritative
+   list lives next to the code that imports it instead of having to be
+   reverse-engineered from `main.js`.
+
+2. **Do not present that as the installation mechanism.** A theme consumed as a
+   git submodule (or a Hugo Module) is not an npm package, so a consumer's
+   `npm install` never reads the theme's `package.json`. Hugo's `js.Build` resolves
+   imports from the **project root's** `node_modules`, so the consuming site must
+   install these packages itself regardless. Declaring them in the theme is
+   documentation and serves the theme's own dev loop and `exampleSite` — it is not
+   a fix on its own. The README must state the required root install explicitly:
+
+   ```bash
+   npm i @alpinejs/csp @alpinejs/focus leaflet \
+     @fortawesome/fontawesome-svg-core \
+     @fortawesome/free-solid-svg-icons \
+     @fortawesome/free-regular-svg-icons \
+     @fortawesome/free-brands-svg-icons
+   ```
+
+   This is also why `postinstall: cd themes/ryder && npm install` appeared here at
+   all — it installs into `themes/ryder/node_modules`, which `js.Build` does not
+   consult. It was cargo-culted around the real requirement, not a solution to it.
+
+3. Add a build-time guard so the failure is legible: have `head/js.html` check for
+   a sentinel import and `errorf` naming the missing packages and the install
+   command, rather than surfacing a raw esbuild resolution error.
+
+### 1.8 `[build] writeStats` and cachebusters live only in `exampleSite`
+
+The theme's `tailwind.config.js:6` globs `./hugo_stats.json`, and the theme's
+`AGENTS.md` states that `exampleSite/hugo_stats.json` is *"intentionally tracked
+because Tailwind clean builds depend on it"* — so the theme knows the file
+matters. But `writeStats = true` and the three `[[build.cachebusters]]` rules
+appear only at `exampleSite/config/_default/hugo.toml:132-142`. The theme's own
+`hugo.toml` has just `[module]`, `[outputFormats]`, and `[outputs]`.
+
+Consequences for every consumer:
+
+- `hugo_stats.json` is never generated, so that `content` entry is inert. Class
+  discovery falls back to the `layouts/**/*.html` globs — which happens to cover
+  the site, but any class assembled dynamically in a template is silently purged.
+- With no cachebusters, `hugo server` serves stale CSS/JS after edits to
+  `tailwind.config.js` or to assets.
+
+**Fix.** Move `[build] writeStats` and the cachebuster rules into the theme's own
+`hugo.toml`. Hugo merges theme config into the site's, so consumers inherit them.
+
+### 1.9 The `-fun` variant targets do not exist, and `REWRITE.md` says they do
+
+`layouts/partials/` at `a95ed03` contains exactly three of these files:
+`header.html`, `footer.html`, `menu.html`. There is **no `header-fun.html` and no
+`footer-fun.html`**, and `grep` finds zero `-fun` references anywhere in
+`layouts/`, `exampleSite/config/`, or `README.md`.
+
+`REWRITE.md` states otherwise, in five places and with checked boxes:
+
+- line 45 identifies the bug — *"`footer-fun.html` doesn't exist but `baseof.html`
+  supports `footerType = "-fun"` — will silently fail"*
+- line 86 marks it fixed — *"[x] Created `footer-fun.html` … The `footerType =
+  "-fun"` param in baseof.html now has a real target."*
+- lines 90, 95, 225, and 269 describe *editing* `header-fun.html`
+- Phase 5 defers a *"`-fun` variant suffix rename"* as *"a breaking change for
+  existing users"*, which presumes the variants are live
+
+**The log was accurate when written.** Full history confirms it: `58a9594`
+(2026-03-17, "rewrite phase 2") really did create `footer-fun.html`, exactly as
+line 86 claims, and `header-fun.html` had existed since 2024-09-27. The bug was
+genuinely fixed.
+
+Then **`ea2538c` (2026-03-26, "Refine site frame and simplify footer overrides")
+deleted both** — nine days later, as collateral in an unrelated layout-frame
+refactor. Three details make this the sharpest evidence in the spec:
+
+1. **The dispatch survived its own targets.** `ea2538c` edits `baseof.html` — it is
+   the commit that produced today's `min-h-lvh flex w-full flex-col` wrapper (the
+   one 2.7 is about) — but leaves `{{- partial (printf "header%s.html" $headerType) . }}`
+   untouched. The mechanism stayed; the only shipped variants it could resolve were
+   removed in the same commit.
+2. **`REWRITE.md` was edited in that very commit**, and the `-fun` claims were
+   missed. The diff removes an unrelated `footerLayout = "stacked"` bullet and a
+   trailing newline. The file was open; the five stale references were simply not
+   noticed.
+3. **`templates.Exists` has never appeared in `baseof.html`** across all 419
+   commits. There has never been anything to catch this.
+
+So the theme identified a silent-failure bug, fixed it, and reintroduced it nine
+days later while editing both the dispatch and the log that documented the fix —
+and nothing anywhere reported it. That is not carelessness; it is exactly what
+happens when a template resolves partial names by string concatenation with no
+existence check.
+
+**User-facing impact is low** — `-fun` is not documented in the README or
+`exampleSite`, so nobody is likely to be setting it. The damage is to maintainers:
+`REWRITE.md` is the theme's own account of what was done, and a maintainer or
+coding agent reading it will believe those partials exist.
+
+**Fix.** Implement 2.6's `templates.Exists` guard, which makes this class of bug
+self-reporting rather than dependent on someone noticing. Then delete the `-fun`
+references from `REWRITE.md` and reword the Phase 5 deferral, adding a note that
+`ea2538c` removed the variants — the log's value is as a record, so correct it
+rather than silently rewriting history.
+
+This also gates issue **#5** (footer templates) — see *Cross-check against upstream
+issues* below.
+
+---
+
+## Tier 2 — Missing extension points
+
+Each of these forced a full-file fork in the site's `layouts/`.
+
+### 2.1 No data-backed, feed-less list layout — the biggest structural gap
+
+`_default/list.html` is hardwired to `.Paginate` over `.Pages`: title, `.Content`,
+paginated card grid. `listCardType` swaps the *card* but not the surrounding
+pagination shell. There is no `listSource` param and no way to suppress the feed.
+
+Every page on the site is a data-driven singleton with zero child pages, sourced
+from `data/*.json`. So **six of seven fork the same template**:
+
+| Site file | Shadows |
+|---|---|
+| `layouts/about/list.html` | `_default/list.html` |
+| `layouts/music/list.html` | `_default/list.html` |
+| `layouts/shows/list.html` | `_default/list.html` |
+| `layouts/press/list.html` | `_default/list.html` |
+| `layouts/shop/list.html` | `_default/list.html` |
+| `layouts/contact/list.html` | `_default/list.html` |
+| `layouts/music/streaming.html` | no counterpart at all |
+
+None shares a line with the theme.
+
+**Fix.** Ship `_default/list-plain.html` — title + `.Content`, no feed —
+selectable via `listType` or `listCardType = "none"`. That alone lets `about`,
+`contact`, and `press` drop their forks. Additive, not breaking.
+
+**Related.** The empty-data idiom is hand-rolled **seven times** across this
+site's `layouts/`, e.g. `layouts/press/list.html:2-3`:
+
+```go-html-template
+{{ $press := .Site.Data.press.items | default slice }}
+{{ if gt (len $press) 0 }}
+```
+
+Ship `partials/utils/data-items.html` as a returning partial so it is written
+once.
+
+### 2.2 `head/schema.html` is monolithic with no seam
+
+**Breaking — v0.3.0.**
+
+The theme's `head/schema.html` (162 lines) emits, per page: `WebPage` (home) or
+`BlogPosting`, plus `Organization` on home, plus one or two `BreadcrumbList`
+blocks. It is called from `common-partials/head-seo.html:9`, whose only
+extensibility is a single hardcoded branch to `schema-recipe.html`.
+
+To emit `MusicGroup` / `MusicEvent` / `MusicAlbum`, the site replaced the file
+outright — and thereby **silently dropped `WebPage`, `Organization`, and
+`BreadcrumbList` entirely**. That is a pure loss forced by the missing hook. The
+theme README still advertises those types, and the site's internal SEO docs
+still believe it receives them.
+
+Worth noting: `partials/extend_head.html` is an empty, sanctioned head-injection
+hook. The site could have added its MusicGroup block there and kept the theme's
+schema — but nothing documents that, so the one seam that *did* exist went unused.
+
+**Fix.** Four parts:
+
+1. Rewrite the theme partial to build Hugo `dict`s and `jsonify` them instead of
+   hand-writing JSON strings. The site's `layouts/partials/head/schema.html:9-20`
+   is the reference implementation — use it. This eliminates 1.2 structurally
+   rather than by vigilance.
+2. Add a no-op `head/schema-extra.html`, called from `head-seo.html`, mirroring
+   the `extend_head.html` pattern.
+3. Add `params.schema.type` (default `"Organization"`) so the site-wide entity can
+   be `MusicGroup`, `Person`, or `LocalBusiness` without overriding anything.
+4. Fix in passing: the file mixes three homepage tests — `eq .Title .Site.Title`
+   (line 3), `.IsHome` (line 90), and `ne .Title .Site.Title` (line 103).
+   Standardize on `.IsHome`; the title-comparison forms give any page sharing the
+   site's title homepage schema. Also: line 84 inlining the entire page body into
+   `articleBody`, inflating every page; line 98's comma-dependent `"email"`
+   emission.
+
+Then document `extend_head.html` in the README.
+
+**Migration note.** JSON-LD output changes shape. Sites should revalidate at
+Google's Rich Results Test after upgrading. Practical risk is low — per 1.2, the
+current output never parsed.
+
+### 2.3 No per-page OG image
+
+`get-featured-image.html` resolves only page-bundle resources matching
+`*feature*`, `*cover*`, or `*thumbnail*`, then falls through to the *generated*
+text-on-image card. There is no front-matter escape hatch.
+
+The site's pages are all bundle-less `_index.md` sections, so every page would
+have received a generated card. It wanted seven hand-designed 1200×630 PNGs, so it
+discarded the resolver — 47 lines down to 4 — taking the theme's entire OG
+generator (`ogImageText.x/y/fontColor/fontName`, the Special Elite and Titillium
+fonts, `opengraph-base.png`) out of service as collateral.
+
+**Fix.** Resolve in order: `og_image` (front matter) → `og_image_default` (site) →
+page-bundle resources → generator. Strictly widens the chain; not breaking.
+
+### 2.4 No conditional or data-driven menu entries
+
+`menu.html` walks `site.Menus` only. "Show Press in nav only when
+`data/press.json` has items" is a documented invariant of the site that
+`[[menus.main]]` cannot express. So the site forked the
+entire nav to append five lines — and now repeats them across **four** files
+(`menu-verdezul.html:20-22`, `header-dark.html`, `header-home.html`,
+`header-nowhite.html`):
+
+```go-html-template
+{{ if gt (len ($.Site.Data.press.items | default slice)) 0 }}
+<li><a href="/press/" {{ if eq $.RelPermalink "/press/" }}aria-current="page"{{ end }}>Press</a></li>
+{{ end }}
+```
+
+**Fix.** Support a `showIf` / `hideIfEmptyData` key in `[menus.main.params]`
+naming a `data/*.json` file whose `items` array must be non-empty for the entry to
+render; honor it in `menu.html`. Not breaking.
+
+This is the highest-leverage nav fix — it also lets the site delete three
+orphaned nav partials.
+
+### 2.5 Variant swap is all-or-nothing, so cosmetic variants need duplicate files
+
+`headerType` is the only per-page hook, and it swaps the whole template. The site
+has four near-identical nav files expressing *three background treatments*:
+
+- `header-dark.html` is **byte-identical** to `menu-verdezul.html`
+- `header-home.html` differs only in classes and a dropped logo
+- `header-nowhite.html` is dead — no `headerType = "-nowhite"` anywhere
+
+The theme's own `header.html:8-20` already accepts page-overridable
+`twClasses.headerBackgroundFrameOuter`, `…Inner`, and `…headerBackgroundImage` —
+exactly the right mechanism, but unreachable from a custom variant. Cost on
+record: commit `148e980`, one visual change ("apply pill nav treatment to all
+pages") applied to two files.
+
+Forking also loses real theme features: two-level menus, `submenuTrigger`, and
+`IsMenuCurrent` / `HasMenuCurrent`. The site reimplements active state less
+correctly with `hasPrefix`, and duplicates the theme's `mobileMenu` Alpine
+component as `vzNav`.
+
+**Fix.** Honor a `navClass` / `headerClass` `.Param` in the base header, and
+document the "one variant plus `.Param` for the skin" pattern. Not breaking.
+
+### 2.6 Variant dispatch has no existence guard
+
+`baseof.html:12` and `:25`:
+
+```go-html-template
+{{- partial (printf "header%s.html" $headerType) . }}
+```
+
+`header.html:50` does the same for `menuType`. A typo'd suffix is a cryptic Hugo
+failure that never names the param responsible. The theme has already been bitten
+by this class of bug — `REWRITE.md:45` records `footerType = "-fun"` pointing at a
+partial that did not exist.
+
+**Fix.** Guard with `templates.Exists`, `warnf` the param name and the resolved
+partial, and fall back to the base variant. Not breaking.
+
+### 2.7 Shell classes are unconfigurable and the wrapper has no hook
+
+`baseof.html:6` hardcodes the `<body>` classes. `[params.twClasses]` covers header
+and footer but **not the body** — which is the other half of why 1.5 needs
+`!important`.
+
+Worse, `baseof.html:10`'s `<div class="min-h-lvh flex w-full flex-col">` carries
+only utility classes — no stable hook class — and is unpositioned, so the site
+reaches into it from CSS
+(`verdezul.css:1073`):
+
+```css
+body:has(.vz-nav--home) > div:not(.fixed) { position: relative; }
+```
+
+The `:not(.fixed)` exists solely to avoid also matching
+`tw-size-indicator.html:2` — a **dev-only** debug partial that `baseof.html:7-9`
+injects as a `<body>` sibling under `not hugo.IsProduction`. A production CSS rule
+is coupled to a dev-only partial's position in the DOM. Either changing means a
+silently broken homepage nav.
+
+**Fix.** Add `twClasses.body`; give the wrapper a stable hook class
+(e.g. `site-shell`) with `position: relative`; move `tw-size-indicator` inside the
+wrapper so it is not a body sibling. Not breaking.
+
+---
+
+## Tier 3 — Packaging and build
+
+All breaking. **v0.3.0.**
+
+### 3.1 Ship a Tailwind preset
+
+The theme's `tailwind.config.js` is a *site* config, not a theme config. Its
+`content` array (lines 5-14) globs `./exampleSite/hugo_stats.json`,
+`./exampleSite/content/**/*.md`, and — from inside the theme itself —
+`"./themes/ryder/layouts/**/*.html"`. None of that resolves sensibly from a
+consumer's project root, so every consumer rewrites `content` wholesale, as this
+site does at `tailwind.config.js:5-11`.
+
+**Fix.** Ship `tailwind.preset.js` carrying only `theme`, `darkMode`, and
+`plugins` — no `content`. Keep `tailwind.config.js` as a thin wrapper for the
+theme's own dev loop. Document the consumer pattern:
+
+```js
+module.exports = {
+  presets: [require('./themes/ryder/tailwind.preset.js')],
+  content: [
+    './themes/ryder/layouts/**/*.html',
+    './layouts/**/*.html',
+    './content/**/*.md',
+    './hugo_stats.json',
+  ],
+};
+```
+
+**Breaking** for anyone requiring the theme config directly.
+
+### 3.2 Delete `assets/css/style.css`
+
+A committed 125 KB Tailwind build artifact that no template reads.
+`head/css.html:1` resolves `css/main.css` and pipes it through `css.PostCSS`;
+grepping the theme for `style.css` returns zero references. It ships to every
+consumer for nothing.
+
+**Breaking** only for a site that resolves it by hand.
+
+### 3.3 Retire the vestigial `*-tw` scripts
+
+`package.json:7-9` runs the Tailwind CLI to produce 3.2's dead artifact. But
+Tailwind already compiles **inside** the Hugo build, via `head/css.html:9`
+(`css.PostCSS`) plus `postcss.config.js`. The scripts are dead weight.
+
+The problem is that `README.md:470-471` presents them as *the* build workflow, and
+that misdirection has propagated downstream into the site's repo:
+
+- the site's build-commands doc insists "`hugo server` alone won't rebuild CSS"
+  and mandates a two-terminal dev loop that is not actually required
+- the same doc also names the wrong output path
+  (`themes/ryder/assets/css/style.css`)
+- `vercel.json` runs `hugo --minify` alone, contradicting the site's own docs
+- the site's `assets/css/tw-built.css` is written, gitignored, and never consumed
+
+**Fix.** Delete `build-tw`, `watch-tw`, and `deploy-tw`. Replace the README
+section with the real requirement: a consuming site needs `tailwindcss`,
+`postcss`, `postcss-cli`, and `autoprefixer` at its project root plus a
+`postcss.config.js` — and then `hugo server` alone suffices.
+
+**Breaking** for anyone invoking the scripts.
+
+### 3.4 Drop the redundant `[outputs]` guidance
+
+The theme's `hugo.toml:13-14` already declares
+`home = ["HTML", "RSS", "LLMSTxt"]` alongside the `LLMSTxt` output format, and
+theme config merges into the site's. So the site's `hugo.toml:28-29` is a
+duplicate, as is the instruction in the site's SEO docs to add it.
+
+**Fix.** Say so in the README. Not breaking.
+
+---
+
+## Tier 4 — CSP-safe Alpine
+
+The largest source of production breakage on the site, and entirely a theme-level
+gap.
+
+`main.js:77` bundles `@alpinejs/csp`, whose expression evaluator **cannot evaluate
+calls, arrow functions, or member calls in inline directives**. It does not throw.
+The HTML renders, no console error appears, and the handler simply never fires.
+
+Three separate silent outages, all in git history:
+
+| Commit | What broke |
+|---|---|
+| `e7bbfe1` | Six PostHog click events (`social_follow_click`, `spotify_play_click`, `merch_click`, `ticket_link_click`, `press_link_click`, `youtube_play_click`) never reached PostHog. The commit also had to *correct the site's own docs*, which had been prescribing the broken pattern. |
+| `d52b9cc` | The contact form "was never actually functional" — an entire Resend serverless endpoint was built against a handler that never ran. |
+| `3d620e9` | The email signup "never worked", same cause. |
+
+Neither the theme's `README.md` nor its `AGENTS.md` mentions the restriction. So
+the site wrote `vzTrack`, `contactForm`, and `subscribeForm` in
+`assets/js/extended.js`, and the workaround is now a comment copy-pasted into
+**ten** templates:
+
+```go-html-template
+{{/* vzTrack: CSP-safe Alpine can't eval inline capture() — see extended.js */}}
+```
+
+Every one of those three components is theme-generic. None should have been
+site code.
+
+### 4.1 Ship `ryderTrack`
+
+Register `Alpine.data('ryderTrack')` in `main.js`, reading `data-track-event` and
+`data-track-props` off `event.currentTarget` and forwarding to whichever provider
+`analytics_provider` selects. Port from `assets/js/extended.js:69-77`, generalized
+past PostHog.
+
+Usage becomes:
+
+```html
+<a x-data="ryderTrack" @click="track"
+   data-track-event="ticket_link_click" data-track-props='{"venue":"…"}'>
+```
+
+The site's `vzTrack` and all ten comments then go away. Not breaking.
+
+### 4.2 Ship `ryderForm`
+
+Register `Alpine.data('ryderForm')` for the declarative case both site forms need:
+POST JSON to `data-form-action`, expose `status` as `loading` / `success` /
+`error`, honor a `_gotcha` honeypot, and fire an optional `data-track-event` on
+success. Port from `extended.js:10-64`, which implements exactly this twice with
+the endpoint hardcoded.
+
+Pair with a README note that the action host needs `params.csp.connectSrc`. Not
+breaking.
+
+### 4.3 `params.csp.scriptSrcHashes`, and PostHog without `'unsafe-inline'`
+
+**Breaking — v0.3.0.**
+
+Two problems compound. `posthog.html:18-27` inlines the bootstrap snippet, so
+`head/csp.html:55-56` appends `'unsafe-inline'` to `script-src` for **every** PostHog
+site — giving away the CSP's most valuable directive by default. Separately,
+because the policy ships as a `<meta http-equiv>` tag (`head/csp.html:135`), **nonces
+are impossible**, so a site with any inline script of its own has no option but
+blanket `'unsafe-inline'`.
+
+The site needs it for both reasons — PostHog, *and* its own client-side date
+re-partitioner at `layouts/shows/list.html:27-50` — which is why `hugo.toml:21`
+sets `scriptSrc = "'unsafe-inline'"` manually. The CSP partial's whole purpose is
+defeated for the site.
+
+**Fix both.** Build the PostHog snippet with
+`resources.FromString | js.Build | fingerprint` and load it via `src` +
+`integrity`, then stop appending `'unsafe-inline'`. And add
+`params.csp.scriptSrcHashes = ["sha256-…"]` so a site with one inline script does
+not disable script CSP wholesale.
+
+The hash pattern already exists in-house: `head/csp.html:43-44` does exactly this for
+Plausible advanced mode. PostHog receiving `'unsafe-inline'` is an inconsistency,
+not a constraint. Note also that `head/csp.html:70-71` already documents *why*
+`style-src` must keep `'unsafe-inline'` (Alpine's `x-show` writes inline styles) —
+`script-src` deserves the same explicit, documented treatment rather than a silent
+widening.
+
+**Migration note.** Sites relying on the widened policy must add their own hosts
+or hashes.
+
+### 4.4 Add a dev-only CSP-Alpine linter
+
+New `assets/js/cspLint.js`, loaded by `head/js.html` only when
+`hugo.Environment == "development"`. Query every `[x-on\:click]` / `[\@click]` and
+the other directive attributes; `console.warn` when a value contains `(` or `=>`,
+naming the element and pointing at the `Alpine.data` pattern.
+
+Cheap, and it catches precisely the failure mode that stayed invisible through
+three outages — including the live regression at the site's
+`layouts/_default/home.html:6-8`, which reintroduced the exact pattern `e7bbfe1`
+eradicated.
+
+### 4.5 Document it
+
+A README section stating the constraint plainly, both new primitives, and the
+`assets/js/extended.js` escape hatch — the theme's sanctioned custom-JS hook (a
+358-byte comment-only stub, imported by `main.js`'s final line), **currently
+documented nowhere**.
+
+That hook is the best-designed seam in the theme: it shadows cleanly via Hugo's
+union asset filesystem, loads before `Alpine.start()`, and loses nothing when
+overridden. The CSS and schema hooks should follow its model.
+
+---
+
+## Tier 5 — Missing primitives
+
+Smaller, all additive. Ship alongside Tier 2.
+
+| # | Gap | Evidence from the site |
+|---|---|---|
+| 5.1 | No `youtube` or `spotify` shortcode — despite `exampleSite`'s CSP already allowlisting `youtube-nocookie.com` and the theme bundling the `faSpotify` icon. The *CSP* anticipates YouTube; the shortcode does not exist. | Site wrote `shortcodes/youtube-embed.html` and `shortcodes/spotify-embed.html` |
+| 5.2 | No video lightbox beside the image one. `main.js` ships `imageGallery` for images only. | Site wrote `youtube-thumb.html`, `youtube-modal.html`, and the `vzLightbox` component |
+| 5.3 | `utils/socialslist.html:1` accepts only `data/social.json` shaped `{main:[{title,icon,link,weight}]}`. A flat name→URL map — the shape Decap CMS produces, and what the site has — yields nil, so the footer renders no socials at all. Compounding it, `main.js` tree-shakes only `faSpotify` and `faGithub` from the brand set, so Instagram, TikTok, Apple Music, and Tidal have no icon even with the right data shape. | 10 hand-rolled inline SVG `<path>` blocks across `footer-verdezul.html` and `contact/list.html`; already tracked in the site's TODO |
+| 5.4 | `logo.html:13` hardwires `bg-neutral-200 hover:bg-neutral-300 … p-3 sm:p-3` — a grey rounded box with padding, not optional. | Three site nav partials inline their own `<img>` rather than call the partial |
+| 5.5 | `head/favicon.html` pins `/favicon.ico?v=4`. No param, no apple-touch-icon, no webmanifest. | Site overrides it — cheaply, since `head.html:17` uses `partialCached` |
+| 5.6 | `showHomeFeed` is read only by `_default/home.html`, so it is a no-op for any site that overrides the home layout. Related: no non-blog home layout is reachable by param — `hidden-home/baseof.html` exists but is a *baseof*, not a `main` block, so it cannot be selected without changing `type` or `layout`. | `hugo.toml:14` is dead config; site forked `_default/home.html` (101 lines → 26, zero shared) |
+
+For 5.3, prefer accepting **both** social data shapes and shipping inline SVGs for
+the common music platforms, over expanding the tree-shaken Font Awesome brand set.
+
+For 5.4, either add a `logo_wrapperClass` param or drop the wrapper chrome when
+`logo_png` is set. Note also that the theme reads `.Param "logo_png"`
+(page-overridable) while the site reads `.Site.Params.logo_png` (site-only) — a
+divergent contract worth settling.
+
+---
+
+## Migration path for existing Ryder sites
+
+Ryder is consumed as a git submodule pinned to a commit, so **nobody upgrades by
+accident** — a site moves only when someone runs `git submodule update --remote`.
+That makes the upgrade safe to stage, and makes tagged releases essential: sites
+need something to pin to other than a commit SHA.
+
+### The hazard that dominates all others: silent stale overrides
+
+Hugo template overrides do not conflict. A site file at
+`layouts/partials/head/schema.html` **wins silently** over the theme's version
+forever — no warning, no merge marker, no signal that the theme's copy moved on.
+
+So the most likely outcome of this release is not breakage. It is a site upgrading,
+seeing green, and **receiving none of the fixes** because it overrode the exact
+files that got fixed. The site is the worst case: it overrides
+`head/schema.html`, `get-featured-image.html`, and `head/favicon.html` — which is
+to say items 1.2, 1.3, 2.2, 2.3, and 5.5 would all land upstream and change
+nothing here until the overrides are deleted.
+
+**Do this before upgrading anything.** List your overrides and diff each against
+the theme:
+
+```bash
+# every site file that shadows a theme file
+cd layouts && find . -type f | while read -r f; do
+  [ -f "../themes/ryder/layouts/$f" ] && echo "$f"
+done
+```
+
+For each hit, decide: delete the override (the theme now does it), rebase your
+changes onto the theme's new version, or keep it deliberately and record why.
+Anything you keep is a fix you are opting out of — that is fine, but it should be
+a decision rather than an accident.
+
+### Upgrade order
+
+Go one release at a time — `v0.2.3 → v0.2.4 → v0.2.5 → v0.3.0` — building and
+eyeballing the site between each. Jumping straight to v0.3.0 bundles four breaking
+changes with ~25 behavior changes, and if something moves you will not know which
+item caused it. Each step is a separate submodule bump, so each is separately
+revertible:
+
+```bash
+git submodule update --remote themes/ryder   # or: cd themes/ryder && git checkout v0.2.4
+git -C themes/ryder describe --tags
+npm install && hugo --minify
+```
+
+Rollback is a one-liner at any point: `git -C themes/ryder checkout <previous-tag>`
+and commit the gitlink.
+
+### v0.2.4 — no config changes required, but three visible effects
+
+Nothing here is breaking. Two items, though, change what a site *emits*, which is
+worth expecting rather than discovering.
+
+| Item | What a site sees | Action |
+|---|---|---|
+| 1.1 getenv | A new build warning if `PUBLIC_POSTHOG_*` are set without `[security.funcs] getenv`. Adding it means **analytics start working for the first time** — expect a step change in PostHog, not a bug. | Add the `[security]` block, or move to `posthog_key` / `posthog_host` params |
+| 1.2 JSON-LD | Structured data becomes parseable, so search engines start reading it. Search Console may report *new* errors — those are pre-existing problems that were invisible while nothing parsed. | Revalidate at Google's Rich Results Test |
+| 1.5 dark mode | Nothing, by design — see the default-mapping table in 1.5. Sites wanting light-only must now say `darkMode = "off"`. | Set it if you were fighting dark mode in CSS, then delete the CSS workaround |
+| 1.3 OG resolver | A named `errorf` instead of a nil-pointer panic. Same trigger conditions, so no new failures. | none |
+| 1.4 footer guard | Sites without `[params.footer]` stop erroring. | none |
+| 1.6 CSP frame-src | Embed hosts are added automatically. A site that deliberately tightened `frameSrc` may find it **loosened**. | Diff the emitted `<meta http-equiv="Content-Security-Policy">` before and after |
+| 1.7 JS deps | No change to behavior — the required root install was always required. | Optionally delete `postinstall: cd themes/ryder && npm install`, which never did anything useful |
+| 1.8 writeStats | `hugo_stats.json` starts being written at the project root, and cachebusters begin applying in dev. Site config still wins over theme config, so an existing `[build]` block is unaffected. | Add `hugo_stats.json` to `.gitignore`, or track it deliberately |
+
+### v0.2.5 — additive, with one CSS risk
+
+Most of this tier is opt-in: `list-plain.html` needs `listType`, menu `showIf`
+needs a menu param, `navClass` needs setting, `ryderTrack` / `ryderForm` need
+`x-data`. Nothing changes until you reach for it.
+
+Three exceptions:
+
+- **2.7 is the one to test carefully.** Giving `baseof.html`'s wrapper `<div>` a
+  `site-shell` class plus `position: relative` creates a containing block, which
+  can move any absolutely-positioned descendant. And relocating
+  `tw-size-indicator` inside the wrapper changes the `<body>`'s direct children —
+  which breaks selectors written against them. **The site would break**: its
+  `body:has(.vz-nav--home) > div:not(.fixed)` rule exists precisely to navigate
+  that structure. Grep your CSS for `body >` before upgrading.
+- **2.6 turns a hard failure soft.** A typo'd `headerType` currently fails the
+  build; afterwards it warns and renders the base header. That is better, but a
+  site that has been relying on the build to catch a missing variant will now ship
+  a wrong-looking page instead. Watch the build log for the new warning.
+- **2.3 widens the OG chain** to read `og_image` front matter. If you already use
+  an `og_image` field for something else, it will now be picked up.
+
+### v0.3.0 — four breaking changes
+
+Ranked by how likely they are to hurt, worst first.
+
+**1. Tier 3.3 — the `*-tw` scripts are deleted. This breaks build commands, not
+rendering.** Any CI, Vercel, or Netlify command that runs
+`npm run build-tw && hugo --minify` will fail on a missing script. Before
+upgrading: confirm your build works with `hugo --minify` alone, ensure
+`tailwindcss`, `postcss`, `postcss-cli`, and `autoprefixer` are at your project
+root with a `postcss.config.js`, then drop the script from every build command and
+from your docs. Sites also inherit 3.2 — if anything resolves
+`themes/ryder/assets/css/style.css` by hand, remove it.
+
+**2. Tier 4.3 — dropping `'unsafe-inline'` will silently break inline scripts in
+production.** CSP violations do not fail the build; they fail in the visitor's
+browser. Any site with its own inline `<script>` will find it blocked after this
+lands. Before upgrading: grep your templates for `<script>` without a `src`. For
+each, either add its hash to the new `params.csp.scriptSrcHashes`, move it into
+`assets/js/extended.js`, or set `params.csp.scriptSrc = "'unsafe-inline'"`
+explicitly — the point of the change is that widening becomes a decision instead
+of a default. Verify with a production build and a browser console showing zero CSP
+violations, not by reading the config.
+
+**3. Tier 2.2 — JSON-LD output changes shape.** If you override
+`head/schema.html`, this is your cue to delete the override and move your additions
+into the new `head/schema-extra.html`, setting `params.schema.type` for the
+site-wide entity. If you do not override it, revalidate at Google's Rich Results
+Test. Per 1.2 the old output never parsed, so the practical risk is low — but
+verify rather than assume.
+
+**4. Tier 3.1 — the Tailwind config becomes a preset.** Any site whose
+`tailwind.config.js` does `require('./themes/ryder/tailwind.config.js')` must
+switch to the `presets: [...]` form shown in 3.1. This one fails loudly and
+immediately at build, so it is the least dangerous of the four.
+
+### What the theme owes consumers
+
+The migration only works if the theme side makes it followable:
+
+- **Tag releases, and ship from the tag.** The theme already tags — 11 of them
+  through `v0.2.3` — so the gap is not tagging but *release discipline*. The site
+  pins `a95ed03`, which `git describe` resolves to **`v0.2.3-3-ga95ed03`**: three
+  commits past the last tag, on unreleased work. Meanwhile `theme.toml` still
+  reads `version = 'v0.2.3'`, so anything reading it believes the site is on the
+  tagged release when it is not. Cut a tag for what you intend consumers to run,
+  bump `theme.toml` in the same commit, and tell sites to pin tags rather than
+  tips. Making the existing tags annotated rather than lightweight would also let
+  them carry release notes.
+- **Ship a `CHANGELOG.md`** with a `### Breaking` heading per release, and link
+  each entry to its item number in this spec.
+- **Write `docs/migration/v0.3.0.md`** in the theme repo — the consumer-facing
+  version of this section, since a site upgrading Ryder should not have to read a
+  band's internal AI docs to find it.
+- **Update `exampleSite` alongside every change**, so it doubles as the reference
+  implementation a migrating site can diff against.
+- **Correct `REWRITE.md`**, which currently describes files that do not exist — see
+  1.9.
+
+### Which sites this affects
+
+`arts-link/ryder` is public and MIT, with a small consumer set: the site, the
+author's own sites (`REWRITE.md` records affiliate tags for `artslink-20`,
+`benstrawbridge-20`, and `grrquarterly-20`, implying three), and whatever external
+sites exist — the repo shows 1 fork and 2 stars, so likely very few. The blast
+radius is small enough that v0.3.0's breaking changes are worth taking rather than
+deferring, which is why 3.1–3.3 and 4.3 are in this release at all rather than
+being carried indefinitely for compatibility.
+
+Note that the author's other sites are older Ryder consumers and may lean on the
+`*-tw` scripts and the committed `style.css` that Tier 3 removes. Audit those
+before publishing v0.3.0.
+
+### Cross-check against upstream issues
+
+Checked against `arts-link/ryder` at `a95ed03` — both the commit the site pins
+**and** upstream `main`, so the spec has no version drift to account for. Note
+that `a95ed03` is `v0.2.3-3-ga95ed03`: the site tracks the branch tip, three
+commits past the last tag, not a released version.
+
+The repo's issue counter reads 7, but that is GitHub's `open_issues_count`, which
+includes pull requests. The real split is **2 open issues and 5 open PRs**, all
+five PRs being Dependabot bumps (`#46`–`#48` GitHub Actions, `#51`–`#52` npm
+groups). Neither issue duplicates anything in this spec, but both intersect it:
+
+| Issue | Status against this spec |
+|---|---|
+| **#5 — Footer templates** (fat / skinny / minimalist), opened 2024-02-05 | Not covered, and **not started**: `layouts/partials/` contains exactly one `footer.html`. Items 2.5 and 2.6 are prerequisites — a family of footer variants is the same variant-dispatch mechanism, and shipping it on today's unguarded `printf` dispatch would reproduce 1.9. Build 2.6's guard first, then this issue becomes cheap. |
+| **#3 — Configurable Google Fonts**, opened 2024-02-05, poked 2026-01-30 | **Partially covered, and the spec should say so.** Titillium Web is hardcoded in four places: `head/fonts.html:4` (the Google Fonts URL, and `partialCached` so it cannot vary), `baseof.html:6` (`font-titillium` on `<body>`), `tailwind.config.js:26` (the `titillium` key), and `assets/css/main.css:157` (a raw `font-family`). Three are theme files a consumer must not edit, so the only available path — overriding `head/fonts.html` — loads a new font while the body class and `main.css` still name the old one. It half-works. Item 2.7 (`twClasses.body`) and 3.1 (the preset, which owns `fontFamily`) remove two of the four; closing #3 additionally needs a `params.fonts` story covering `head/fonts.html` and `main.css:157`. Worth folding into v0.2.5 while 2.7 is open. |
+
+---
+
+## Verification
+
+Acceptance criteria to run in `arts-link/ryder`. Several of these fail today —
+that is the point.
+
+1. **Structured data.** Build `exampleSite`, pipe every `application/ld+json`
+   block through `jq` — must parse. **Fails today** (1.2). Then run the home page
+   and one post through Google's Rich Results Test.
+2. **CSP.** Production build of `exampleSite`; load the leaflet-maps and
+   media-embeds pages in Chromium; assert zero CSP violations in the console.
+   **Fails today** on the uMap iframe (1.6). Add a case beside
+   `tests/e2e/smoke.spec.js`.
+3. **Analytics wiring.** Build `exampleSite` with `PUBLIC_POSTHOG_*` set but no
+   `[security.funcs] getenv` — assert a build warning rather than silence (1.1).
+4. **Alpine primitives.** Playwright: click a `ryderTrack` element with a
+   `window.posthog` stub installed, assert `capture` received the right event name
+   and props. This is the regression test the three outages never had (4.1).
+5. **Dark mode.** Playwright with `colorScheme: 'dark'` against a site configured
+   `darkMode = "off"` — assert `<html>` carries no `dark` class (1.5).
+6. **Missing-param resilience.** Build a fixture site with no `[params.footer]`
+   and no `[params.csp]` — must not error (1.4).
+7. **OG resolver.** Fixture with `og_image_default = "/nope.png"` — assert a named
+   `errorf`, not a nil-pointer panic (1.3).
+8. **Packaging.** Clean clone of a consumer site; `npm install` at the project
+   root only, no `cd themes/ryder`; then `hugo --minify` must succeed (1.7, 3.3).
+
+### The real success metric
+
+Re-point the site's submodule, run `hugo --minify`, and confirm it can **delete**
+all of the following with rendered output unchanged:
+
+- `layouts/partials/head/favicon.html` (5.5)
+- `layouts/partials/common-partials/opengraph/get-featured-image.html` (2.3)
+- the `body { … !important }` block (1.5)
+- the `body:has(…) > div:not(.fixed)` hack (2.7)
+- `vzTrack` and the ten workaround comments (4.1)
+- `header-dark.html`, `header-home.html`, `header-nowhite.html` (2.4, 2.5)
+- `scriptSrc = "'unsafe-inline'"` (4.3)
+- the dead `showHomeFeed` and duplicate `[outputs]` config (5.6, 3.4)
+- `assets/css/tw-built.css` and the three `*-tw` npm scripts (3.3)
+
+That deletion list — not the feature list — is how to tell whether this spec
+worked.
+
+---
+
+## Relationship to existing issues and PRs
+
+Three items close or advance existing issues — the issue bodies should say so
+when the work is filed, so the history connects:
+
+| Spec item | Existing issue |
+|---|---|
+| 2.5, 2.6 | prerequisites for **#5** (footer templates) |
+| 2.7, 3.1 | partial progress on **#3** (configurable fonts); needs a `params.fonts` story to close |
+
+**Start with 2.6.** It is small, non-breaking, and it makes 1.9's whole class of
+bug self-reporting — which means every later variant-related change in this spec
+lands with a safety net that did not exist for the last one.
+
+Note also that the 5 open Dependabot PRs (`#46`–`#48`, `#51`–`#52`) are unrelated
+to this work and can be merged independently — though `#51`/`#52` touch npm groups
+that Tier 3 reorganizes, so merge them before 3.1 rather than after.


### PR DESCRIPTION
Copy of the ryder-v0.3-spec written against a95ed03 in the first real
submodule consumer's repo, adapted per its own handoff instructions:
wikilinks resolved, voice changed to name whatisverdezul.com, the
consumer-only sections dropped. Citations re-verified against this tree,
with corrections folded in: csp.html cited at its real path (head/),
get-featured-image.html lines 7-9, schema.html's three mixed homepage
tests, themeBoot.js's localStorage precedence, and the baseof.html
wrapper described as lacking a stable hook class rather than unclassed.

Tracks #53.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VRxJsK91SRR9AMxwJvhrqq