### PR TITLE
Phase 0: guard variant dispatch with templates.Exists, correct REWRITE.md

### DIFF
--- a/REWRITE.md
+++ b/REWRITE.md
@@ -8,6 +8,8 @@ no dead code, and a cleaner experience for the person setting up a new site with
 
 ---
 
+> **Correction (2026-07-26):** Several entries below reference `header-fun.html`, `footer-fun.html`, and `menu-fun.html` as existing (or instruct work against them). These references were accurate at the time each entry was written — `footer-fun.html` was created 2026-03-17 (Phase 2) and `header-fun.html` predates the rewrite. However, commit `ea2538c` ("Refine site frame and simplify footer overrides", 2026-03-26) deleted both `header-fun.html` and `footer-fun.html` as collateral cleanup, without touching this log or the `headerType`/`footerType` dispatch mechanism that references them. `menu-fun.html` was already removed earlier, in Phase 3 (below). **As of today, no `-fun` variant files ship in this theme** — only `header.html`, `footer.html`, and `menu.html` exist. The entries below are left as originally written for historical accuracy, with `[Update: ...]` notes added where a claim or instruction is now stale.
+
 ## Audit Findings (Pre-Rewrite)
 
 Full code review conducted before any changes. Key findings:
@@ -42,7 +44,7 @@ Mixed PascalCase, camelCase, and all-lowercase in `hugo.toml` params:
 - Custom TOC vs `UseHugoToc` — two systems in parallel, one should win
 
 ### Gaps / Broken Promises
-- `footer-fun.html` doesn't exist but `baseof.html` supports `footerType = "-fun"` — will silently fail
+- `footer-fun.html` doesn't exist but `baseof.html` supports `footerType = "-fun"` — will silently fail [Update: `footer-fun.html` was created in Phase 2 below, then deleted again in `ea2538c` (2026-03-26) — this gap is true again today. Phase 0 (2026-07-26) added a `templates.Exists` guard so an unrecognized `footerType` now warns naming the bad param/partial and falls back to `footer.html` instead of failing.]
 - `archetypes/recipe.md` bug: `recipeInstructions` is a string but `schema-recipe.html` treats it as an array
 - CI/CD (GitHub Actions) uses Hugo `0.138.0` but theme requires `0.146+` — masks compatibility bugs
 - `package.json` at root: `name = "benstraw"`, `license = "ISC"` (should be MIT), description is a Markdown fragment
@@ -83,16 +85,16 @@ Shortcodes that are personal site utilities, not theme features:
 - [x] Rename params to camelCase in templates and exampleSite config: `TocOpen→tocOpen`, `UseHugoToc→useHugoToc`, `ShowPubDate→showPubDate`, `enabledebugpanel→enableDebugPanel`
 - [x] Fix `archetypes/recipe.md` (both root and exampleSite) — `recipeInstructions` was a string, now correctly a TOML array of `[[recipeInstructions]]` objects with `name` and `text` fields. Also fixed bare unquoted TOML values in exampleSite version (`recipeCuisine = American` → quoted).
 - [x] Social links: confirmed `[[params.social]]` never existed in templates or config — implementation always used `data/social.json`. CLAUDE.md was already corrected in Phase 1 setup. No template changes needed.
-- [x] Created `footer-fun.html` — simple single-row flex footer (copyright + socials + dark toggle). The `footerType = "-fun"` param in baseof.html now has a real target.
+- [x] Created `footer-fun.html` — simple single-row flex footer (copyright + socials + dark toggle). The `footerType = "-fun"` param in baseof.html now has a real target. [Update: removed in `ea2538c`, 2026-03-26 — no `-fun` variants ship today.]
 - [x] CI/CD Hugo version: `0.138.0` → `0.146.0` (matches stated minimum requirement)
 - [x] Fix `archetypes/default.md` and `archetypes/recipe.md`: `showTOC` → `showToc` to match template (`.Params.showToc` in single.html)
 - [x] Simplify `hidden-home/baseof.html` debug panel condition: `or (.Params.enabledebugpanel) (and (not .Params.enabledebugpanel) (site.Params.enabledebugpanel))` → `.Param "enableDebugPanel"` (standard Hugo cascade)
-- [x] Remove stale comment block from `header-fun.html` ("Not sure I'll use those but leave'm for now")
+- [x] Remove stale comment block from `header-fun.html` ("Not sure I'll use those but leave'm for now") [Update: `header-fun.html` itself was removed in `ea2538c`, 2026-03-26 — see correction note above.]
 
 ### Phase 3 — Consolidate (Remove duplication)
 **Status:** Complete — 2026-03-17
 
-- [x] Merged `menu.html` and `menu-fun.html` into single `menu.html`. Added optional `navClass` param (defaults to `main-menu-nav`; footer menus use `footer-menu-nav`). Deleted `menu-fun.html`. Updated `header-fun.html` to call `menu.html` with `navClass = "main-fun-menu-nav"`. Removed unused `shade` param that was passed but never read.
+- [x] Merged `menu.html` and `menu-fun.html` into single `menu.html`. Added optional `navClass` param (defaults to `main-menu-nav`; footer menus use `footer-menu-nav`). Deleted `menu-fun.html`. Updated `header-fun.html` to call `menu.html` with `navClass = "main-fun-menu-nav"`. Removed unused `shade` param that was passed but never read. [Update: `header-fun.html` was itself removed in `ea2538c`, 2026-03-26 — `header.html` is the only header partial shipping today.]
 - [x] Created `utils/card-meta.html` — returning partial (Hugo `return`) that computes all shared card metadata. Both card templates now call it and receive a dict. Each card is only its rendering logic.
 - [x] Moved ~275 lines of share-buttons CSS from inline `<style>` block into `assets/css/main.css`. Eliminated the duplicate first color set (which lacked `border-color` and `:active` states). Removed dead Google+ network styles. Dynamic values (`margin`, `font-size`) now use CSS custom properties `--sb-margin` and `--sb-font-size` set by a small remaining `<style>` block.
 - [x] Removed dead commented-out navbar toggler CSS from `main.css`
@@ -129,7 +131,7 @@ Surgical visual modernization. No new frameworks, no structural changes, no new 
 - [x] **`static/leaflet/` removed.** The theme ships Leaflet as an npm dependency (used by `main.js` via `import('leaflet')`), and the CSS is in `assets/css/leaflet.css`. The `static/leaflet/` directory was a redundant manual copy (~300KB) serving no purpose in the build pipeline. Marker images referenced by the CSS are served from `static/css/images/` which remains.
 - [x] **`exampleSite/package.json` fixed.** Same issues as root: name, description, license (ISC → MIT), removed spurious `main` field.
 - [ ] **`[params.twClasses]` rename** — deferred. The name is not ideal but renaming is a breaking change requiring a migration guide. Document thoroughly instead.
-- [ ] **`-fun` variant suffix rename** — deferred. Renaming (`headerType = "-fun"` → something descriptive) is a breaking change for existing users. Flag for v0.2 with clear migration note.
+- [x] **`-fun` variant suffix rename** — moot. `header-fun.html` and `footer-fun.html` (and, earlier, `menu-fun.html`) were removed in `ea2538c` (2026-03-26, "Refine site frame and simplify footer overrides") as collateral to unrelated cleanup. No `-fun` variant files ship today, so there is no suffix left to rename or migrate. The `headerType`/`footerType`/`menuType` dispatch mechanism itself is unchanged and still accepts arbitrary suffixes; Phase 0 (2026-07-26) added a `templates.Exists` guard so an unrecognized value now warns naming the bad param and resolved partial, then falls back to `header.html`/`footer.html`/`menu.html`, instead of aborting the build.
 
 ---
 
@@ -194,7 +196,7 @@ Surgical visual modernization. No new frameworks, no structural changes, no new 
 
 **Deferred to v0.2:**
 - `[params.twClasses]` rename — breaking change, needs migration guide
-- `-fun` variant suffix rename — breaking change, needs migration guide
+- `-fun` variant suffix rename — breaking change, needs migration guide [Update: moot — see reworded Phase 5 entry above. `header-fun.html`/`footer-fun.html` were deleted in `ea2538c` (2026-03-26); `header.html`/`footer.html` are the only variants shipping.]
 
 ---
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -9,7 +9,13 @@
   {{ end }}
   <div class="min-h-lvh flex w-full flex-col">
     {{ $headerType := .Param "headerType" | default "" }}
-    {{- partial (printf "header%s.html" $headerType) . }}
+    {{ $headerPartial := printf "header%s.html" $headerType }}
+    {{- if templates.Exists (printf "partials/%s" $headerPartial) }}
+      {{- partial $headerPartial . }}
+    {{- else }}
+      {{- warnf "headerType %q resolves to missing partial %q; falling back to header.html" $headerType $headerPartial }}
+      {{- partial "header.html" . }}
+    {{- end }}
     {{- partial "alphaAlert.html" . }}
     <main class="w-full flex-1">
       {{ $showBreadCrumbs := .Param "showBreadCrumbs" | default true }}
@@ -21,8 +27,14 @@
       {{- block "main" . }}{{- end }}
     </main>
     {{ $footerType := .Param "footerType" | default "" }}
+    {{ $footerPartial := printf "footer%s.html" $footerType }}
     <div class="pb-5">
-      {{- partial (printf "footer%s.html" $footerType) . }}
+      {{- if templates.Exists (printf "partials/%s" $footerPartial) }}
+        {{- partial $footerPartial . }}
+      {{- else }}
+        {{- warnf "footerType %q resolves to missing partial %q; falling back to footer.html" $footerType $footerPartial }}
+        {{- partial "footer.html" . }}
+      {{- end }}
     </div>
   </div>
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -47,7 +47,13 @@ By default it will have a background gradient in cayan.
               <div id="nav-menu" x-bind:class="{ 'hidden': !openMenu, 'block': openMenu }"
                   class="absolute right-0 top-full mt-1 z-50 w-max md:inline md:relative md:top-auto md:mt-0 md:left-auto md:right-0 text-xl ">
                   {{ $menuType := .Param "menuType" | default "" }}
-                  {{- partial (printf "menu%s.html" $menuType) (dict "menuID" "main" "page" . "shade" "rose") -}}
+                  {{ $menuPartial := printf "menu%s.html" $menuType }}
+                  {{- if templates.Exists (printf "partials/%s" $menuPartial) -}}
+                    {{- partial $menuPartial (dict "menuID" "main" "page" . "shade" "rose") -}}
+                  {{- else -}}
+                    {{- warnf "menuType %q resolves to missing partial %q; falling back to menu.html" $menuType $menuPartial -}}
+                    {{- partial "menu.html" (dict "menuID" "main" "page" . "shade" "rose") -}}
+                  {{- end -}}
               </div>
           </div>
       </div>


### PR DESCRIPTION
Phase 0 of the v0.3 plan (#53) — spec items **2.6** and **1.9**. Lands first so every later variant-related change is self-reporting.

## What

- **`layouts/_default/baseof.html`** (header + footer dispatch) and **`layouts/partials/header.html`** (menu dispatch): the `printf "header%s.html"` string-concatenation dispatch is now guarded with `templates.Exists`. On a miss it emits a `warnf` naming both the config param (`headerType` / `footerType` / `menuType`) and the resolved partial filename, then falls back to the base partial. Previously a typo'd suffix aborted the build with a cryptic error naming neither.
- **`REWRITE.md`**: corrected the stale `-fun` variant claims. `footer-fun.html` was genuinely created in Phase 2 (2026-03-17), then `ea2538c` (2026-03-26) deleted both `-fun` files as collateral while editing this very log. Entries are preserved as written with a dated correction block up top and targeted `[Update: …]` notes; the Phase 5 "`-fun` suffix rename" deferral is resolved as moot.

## Verification

Local build with hugo **extended** 0.147.0, exampleSite deps installed:

- Clean build: exit 0, zero errors/warnings — no behavior change on the happy path.
- `headerType = "-nope"` in exampleSite config: build **succeeds** and logs `WARN headerType "-nope" resolves to missing partial "header-nope.html"; falling back to header.html`. Before this change the same config was a hard build failure.

(One local-only accommodation: the `highlight-github` demo page was skipped locally because this sandbox blocks `api.github.com` for `resources.GetRemote` — unrelated to the change; CI builds it normally.)

## Incidental finding

The theme's `hugo.toml` declares `[module.hugoVersion] extended = false`, but exampleSite cannot build without extended Hugo (WebP `.Resize` in the OG pipeline). Worth folding into the spec's Tier 1 docs fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VRxJsK91SRR9AMxwJvhrqq

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRxJsK91SRR9AMxwJvhrqq)_