### PR TITLE
Bump actions/setup-node from v4 to v6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
@@ -30,7 +30,7 @@ jobs:
       HUGO_VERSION: 0.146.0
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm


### PR DESCRIPTION
Supersedes #52... er, #48 (Dependabot's setup-node v4→v6 bump), applied directly.

## Why not just merge #48

An earlier `update_pull_request_branch` call on #48 added a merge commit to its branch that wasn't authored by Dependabot. Dependabot's own bot comment on that PR confirms it now refuses to touch it further ("since this PR has been edited by someone other than Dependabot I haven't updated it"), so neither `·@·d·ependabot r·ebase` nor `·@·d·ependabot r·ecreate` had any effect. Rather than keep retrying, this PR applies the same two-line diff directly.

## What

`actions/setup-node@v4` → `@v6` in both jobs in `.github/workflows/test.yml`, matching what #48 proposed.

## After merge

Close #48 as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VRxJsK91SRR9AMxwJvhrqq

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRxJsK91SRR9AMxwJvhrqq)_