### PR TITLE
v0.4.0 (PR 1): semantic color tokens, accent consolidation, three new components

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ Named after a late Rhodesian Ridgeback/Mastiff companion.
 
 ---
 
+## What's New in v0.4.0
+
+- **Semantic color tokens** — the palette resolves through `--ryder-*` custom properties, so `[params.colors]` can repoint brand, brand-alt, accent, and the header/footer chrome without overriding a single class string. See [Color Tokens](#color-tokens).
+- **One accent instead of six** — the tag cloud's yellow border and the CTA button's fuchsia ring both move to the theme accent (rose). `params.colors.legacyAccents = true` restores them.
+- **Three new components** — a themed [form field](#form-fields) partial for the existing `ryderForm` engine, a `table-wrapper` shortcode that keeps wide tables from pushing the page sideways, and an empty state on list pages that no longer renders a blank page with a dead pager.
+
+Sites upgrading from v0.3.x should read the [v0.4.0 migration guide](docs/migration/v0.4.0.md) — the accent change is the only thing that alters an existing site, and it is one config flag to undo. The reasoning behind the system is recorded in [docs/design-decisions.md](docs/design-decisions.md).
+
+---
+
 ## What's New in v0.3.0
 
 - **Safe, extensible structured data** — JSON-LD is built from Hugo dictionaries and serialized with `jsonify`; use `params.schema.type` and `head/schema-extra.html` to extend it without replacing Ryder's built-in schema.
@@ -649,6 +659,7 @@ enableGitInfo = true
 | `amazon-associate-link` | Affiliate link with disclosure |
 | `font-awesome` | Inline Font Awesome icon |
 | `highlight-github` | GitHub-styled syntax highlight block |
+| `table-wrapper` | Wraps a Markdown table in a themed shell that scrolls horizontally instead of widening the page |
 
 ### Recipe Schema
 
@@ -1010,6 +1021,55 @@ Note the `fontFamily.titillium` entry resolves through
 contradicting it. If you replace `fontFamily` wholesale in your own config,
 keep that indirection or set `twClasses.body` to a class of your own.
 
+### Color Tokens
+
+*New in v0.4.0.* Ryder's colors resolve through CSS custom properties, so you
+can repoint the palette from config instead of overriding class strings one
+element at a time:
+
+```toml
+[params.colors]
+  brand     = "12 74 110"   # logo word 1, nav links, article meta icons, blockquote
+  brand-alt = "54 83 20"    # logo word 2, active nav entry
+  accent    = "217 70 239"  # aside icons, tag chips, tag cloud, CTA ring
+  chrome-from = "24 24 27"  # header/footer gradient start
+  chrome-to   = "63 63 70"  # header/footer gradient end
+```
+
+**Values are RGB channel triplets, not hex** — `"244 63 94"`, not `"#f43f5e"`.
+This is load-bearing, not stylistic: a hex value inside `var()` works for
+`text-`, `bg-`, and `border-`, then silently produces *nothing* for every
+opacity modifier, and Ryder uses those throughout (`border-ryder-accent-300/80`,
+`dark:bg-ryder-accent-950/40`, the share-button fills at `/88`). Channels
+interpolate with Tailwind's `<alpha-value>` and keep them working. A value in
+any other format is ignored, with a build warning naming the key.
+
+Each of `brand`, `brand-alt`, and `accent` also carries a full `50`–`950` ramp,
+because the theme uses more than one shade of each — the nav alone spans
+`brand-100` through `brand-800`. Setting the bare token moves that family's
+canonical shade (`brand` is sky-800, `accent` is rose-500) plus everything keyed
+to it; set individual steps such as `accent-300` when you want the rest to
+follow. Anything left unset keeps the theme default, so a partial override is
+safe.
+
+The preset exposes all of them as ordinary Tailwind colors, usable anywhere you
+write a class — including in `twClasses`:
+
+```
+text-ryder-brand        bg-ryder-accent-50    border-ryder-brand-alt-800
+from-ryder-chrome-from  to-ryder-chrome-to    ring-ryder-accent-300/80
+```
+
+Ryder's own shipped `twClasses` defaults deliberately stay on plain Tailwind
+classes. They get copied into user configs, and a default that references the
+token layer while the copy doesn't leaves you with half a palette. Surfaces
+(`neutral-*`), structural greys, the alert color triples, and the
+Amazon/Spotify button fills are not tokenized either — see
+[docs/design-decisions.md](docs/design-decisions.md) for the reasoning.
+
+Full reference, including which element each token drives:
+`/docs/css-overrides/#color-tokens` on the demo site.
+
 ### Build configuration
 
 **Add this `[build]` block to your own site config** — Hugo merges only a subset of root config sections from themes, and `build` is not one of them, so you do **not** inherit it from Ryder:
@@ -1136,6 +1196,43 @@ or the browser blocks the request:
 ```
 
 Same-origin actions need nothing; `connect-src 'self'` is always present.
+
+#### Form fields
+
+`ryderForm` is the engine; `utils/form-field.html` is the matching visual layer,
+added in v0.4.0 so a themed form no longer means hand-writing the markup above:
+
+```go-html-template
+<form x-data="ryderForm" @submit.prevent="submit"
+      data-form-action="https://api.example.com/subscribe">
+  {{ partial "utils/form-field.html" (dict "name" "email" "type" "email"
+      "label" "Email" "placeholder" "you@example.com" "required" true) }}
+  {{ partial "utils/form-field.html" (dict "name" "message" "type" "textarea"
+      "label" "Message" "help" "Anything else we should know?") }}
+
+  <input type="text" name="_gotcha" tabindex="-1" autocomplete="off"
+         class="hidden" aria-hidden="true">
+
+  {{ partial "utils/form-field.html" (dict "type" "submit" "label" "Subscribe"
+      "successMessage" "Thanks!" "errorMessage" "") }}
+</form>
+```
+
+| Key | Meaning |
+|---|---|
+| `name` | Field name, and the default `id`. Required except for `submit` |
+| `type` | Any text-like input type, plus `textarea` and `submit`. Defaults to `text` |
+| `label` | Visible label; the button text when `type` is `submit` |
+| `placeholder`, `value`, `autocomplete`, `rows` | Passed through when set |
+| `required` | Marks the control required and appends `*` to the label |
+| `help` | Hint text under the control, wired up via `aria-describedby` |
+| `id`, `class` | Override the derived id, or append classes to the control |
+| `successMessage` | `submit` only — a line shown on `x-show="isSuccess"` |
+| `errorMessage` | `submit` only — a fixed message, or `""` to show the engine's own |
+
+The submit button reuses the theme's default CTA class, so it follows
+`params.colors.legacyAccents` along with every other CTA. The honeypot stays
+hand-written: it is one line, and it should not look like a field.
 
 ### The dev-only linter
 

--- a/README.md
+++ b/README.md
@@ -1031,10 +1031,15 @@ element at a time:
 [params.colors]
   brand     = "12 74 110"   # logo word 1, nav links, article meta icons, blockquote
   brand-alt = "54 83 20"    # logo word 2, active nav entry
-  accent    = "217 70 239"  # aside icons, tag chips, tag cloud, CTA ring
-  chrome-from = "24 24 27"  # header/footer gradient start
-  chrome-to   = "63 63 70"  # header/footer gradient end
+  accent    = "217 70 239"  # aside icons, tag chips, tag cloud
 ```
+
+`chrome-from` and `chrome-to` are also declared, but **nothing in the theme
+reads them** — the header and footer gradients come through
+`twClasses.headerBackgroundFrameOuter`, which deliberately stays a literal
+Tailwind string. They exist so you can use `from-ryder-chrome-from` /
+`to-ryder-chrome-to` in class strings of your own; setting them will not retint
+your header.
 
 **Values are RGB channel triplets, not hex** — `"244 63 94"`, not `"#f43f5e"`.
 This is load-bearing, not stylistic: a hex value inside `var()` works for
@@ -1046,11 +1051,16 @@ any other format is ignored, with a build warning naming the key.
 
 Each of `brand`, `brand-alt`, and `accent` also carries a full `50`–`950` ramp,
 because the theme uses more than one shade of each — the nav alone spans
-`brand-100` through `brand-800`. Setting the bare token moves that family's
-canonical shade (`brand` is sky-800, `accent` is rose-500) plus everything keyed
-to it; set individual steps such as `accent-300` when you want the rest to
-follow. Anything left unset keeps the theme default, so a partial override is
-safe.
+`brand-100` through `brand-800`. Setting the bare token moves **only that
+family's canonical step**, and which step that is differs per family: `brand`
+aliases `brand-800`, `brand-alt` aliases `brand-alt-800`, `accent` aliases
+`accent-500`.
+
+This catches people out. The default CTA button uses `accent-600` / `accent-500`
+/ `accent-300` for border, hover, and focus ring — so setting `accent` alone
+moves the hover and leaves the border and ring rose. Set every step a component
+uses; `rg 'ryder-accent-' layouts assets/css` lists them. Anything left unset
+keeps the theme default, so a partial override is safe, just incomplete.
 
 The preset exposes all of them as ordinary Tailwind colors, usable anywhere you
 write a class — including in `twClasses`:

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2,6 +2,67 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Semantic color tokens — the default values behind the `ryder-*` Tailwind
+   classes declared in tailwind.preset.js. Values are space-separated RGB
+   channels, not hex, so `<alpha-value>` can interpolate and opacity modifiers
+   keep working (see the preset's comment).
+
+   The three families carry a full ramp because the theme's own classes span
+   most of it; the step matching each family's canonical shade points back at
+   the headline token, so setting only `--ryder-accent` retints both
+   `ryder-accent` and `ryder-accent-500`.
+
+   A site overrides these from [params.colors] via head/colors.html, which
+   emits its <style> AFTER this stylesheet so the override wins. Do not move
+   that partial ahead of head/css.html. */
+:root {
+  /* brand — sky */
+  --ryder-brand:         7 89 133;    /* sky-800  #075985 */
+  --ryder-brand-50:      240 249 255; /* #f0f9ff */
+  --ryder-brand-100:     224 242 254; /* #e0f2fe */
+  --ryder-brand-200:     186 230 253; /* #bae6fd */
+  --ryder-brand-300:     125 211 252; /* #7dd3fc */
+  --ryder-brand-400:     56 189 248;  /* #38bdf8 */
+  --ryder-brand-500:     14 165 233;  /* #0ea5e9 */
+  --ryder-brand-600:     2 132 199;   /* #0284c7 */
+  --ryder-brand-700:     3 105 161;   /* #0369a1 */
+  --ryder-brand-800:     var(--ryder-brand);
+  --ryder-brand-900:     12 74 110;   /* #0c4a6e */
+  --ryder-brand-950:     8 47 73;     /* #082f49 */
+
+  /* brand-alt — lime */
+  --ryder-brand-alt:     63 98 18;    /* lime-800 #3f6212 */
+  --ryder-brand-alt-50:  247 254 231; /* #f7fee7 */
+  --ryder-brand-alt-100: 236 252 203; /* #ecfccb */
+  --ryder-brand-alt-200: 217 249 157; /* #d9f99d */
+  --ryder-brand-alt-300: 190 242 100; /* #bef264 */
+  --ryder-brand-alt-400: 163 230 53;  /* #a3e635 */
+  --ryder-brand-alt-500: 132 204 22;  /* #84cc16 */
+  --ryder-brand-alt-600: 101 163 13;  /* #65a30d */
+  --ryder-brand-alt-700: 77 124 15;   /* #4d7c0f */
+  --ryder-brand-alt-800: var(--ryder-brand-alt);
+  --ryder-brand-alt-900: 54 83 20;    /* #365314 */
+  --ryder-brand-alt-950: 26 46 5;     /* #1a2e05 */
+
+  /* accent — rose */
+  --ryder-accent:        244 63 94;   /* rose-500 #f43f5e */
+  --ryder-accent-50:     255 241 242; /* #fff1f2 */
+  --ryder-accent-100:    255 228 230; /* #ffe4e6 */
+  --ryder-accent-200:    254 205 211; /* #fecdd3 */
+  --ryder-accent-300:    253 164 175; /* #fda4af */
+  --ryder-accent-400:    251 113 133; /* #fb7185 */
+  --ryder-accent-500:    var(--ryder-accent);
+  --ryder-accent-600:    225 29 72;   /* #e11d48 */
+  --ryder-accent-700:    190 18 60;   /* #be123c */
+  --ryder-accent-800:    159 18 57;   /* #9f1239 */
+  --ryder-accent-900:    136 19 55;   /* #881337 */
+  --ryder-accent-950:    76 5 25;     /* #4c0519 */
+
+  /* chrome — the header/footer gradient endpoints */
+  --ryder-chrome-from:   15 23 42;    /* slate-900 #0f172a */
+  --ryder-chrome-to:     51 65 85;    /* slate-700 #334155 */
+}
+
 .pagination {
   @apply flex list-none;
 }
@@ -80,7 +141,7 @@
   }
 
   .article-header-meta-icon {
-    @apply shrink-0 text-sm text-sky-700 dark:text-sky-300;
+    @apply shrink-0 text-sm text-ryder-brand-700 dark:text-ryder-brand-300;
   }
 
   .article-header-meta-label {
@@ -102,7 +163,7 @@
   }
 
   .aside-taxonomy-icon {
-    @apply text-rose-500;
+    @apply text-ryder-accent-500;
   }
 
   .aside-taxonomy-links {
@@ -110,9 +171,9 @@
   }
 
   .aside-taxonomy-link {
-    @apply inline-flex items-center rounded-md border border-rose-300/80 bg-rose-50 px-2.5 py-1 text-sm text-slate-700;
-    @apply transition-colors duration-150 ease-in-out hover:border-rose-400 hover:bg-rose-100 hover:text-slate-900;
-    @apply dark:border-rose-900/70 dark:bg-rose-950/40 dark:text-slate-200 dark:hover:border-rose-700 dark:hover:bg-rose-900/50;
+    @apply inline-flex items-center rounded-md border border-ryder-accent-300/80 bg-ryder-accent-50 px-2.5 py-1 text-sm text-slate-700;
+    @apply transition-colors duration-150 ease-in-out hover:border-ryder-accent-400 hover:bg-ryder-accent-100 hover:text-slate-900;
+    @apply dark:border-ryder-accent-900/70 dark:bg-ryder-accent-950/40 dark:text-slate-200 dark:hover:border-ryder-accent-700 dark:hover:bg-ryder-accent-900/50;
   }
 
   .aside-toc-group {
@@ -126,7 +187,7 @@
   }
 
   .aside-toc-icon {
-    @apply text-rose-500;
+    @apply text-ryder-accent-500;
   }
 
   .aside-toc-links {
@@ -148,7 +209,7 @@
 
   .aside-toc-links a {
     @apply block rounded-md px-2 py-1.5 text-sm text-slate-700 no-underline transition-colors duration-150 ease-in-out;
-    @apply hover:bg-rose-50 hover:text-slate-900 dark:text-slate-200 dark:hover:bg-rose-950/40 dark:hover:text-white;
+    @apply hover:bg-ryder-accent-50 hover:text-slate-900 dark:text-slate-200 dark:hover:bg-ryder-accent-950/40 dark:hover:text-white;
   }
 
     /* Share buttons (sharingbuttons.io) --- */
@@ -292,6 +353,42 @@
     @apply shadow-md;
   }
 
+  /* Table wrapper (layouts/shortcodes/table-wrapper.html). The shell carries
+     `not-prose`, because @tailwindcss/typography's table rules cannot be
+     restyled from inside prose — so the cell styling has to be re-stated here
+     rather than layered on top. Markdown emits the table, so these are
+     element selectors: there is nowhere to hang a class. */
+  /* `not-prose` is applied in the shortcode markup, not here: the typography
+     plugin's rule is not something @apply can resolve. */
+  .ryder-table {
+    @apply overflow-hidden rounded-xl border border-slate-200/80;
+    @apply dark:border-slate-700/70;
+  }
+
+  .ryder-table-scroll {
+    @apply w-full overflow-x-auto;
+  }
+
+  .ryder-table table {
+    @apply m-0 w-full border-collapse text-left text-sm;
+  }
+
+  .ryder-table th {
+    @apply bg-neutral-100 px-3.5 py-2.5 font-bold dark:bg-neutral-800;
+  }
+
+  .ryder-table td {
+    @apply px-3.5 py-2.5 align-top;
+  }
+
+  .ryder-table tr {
+    @apply border-b border-slate-200/50 dark:border-slate-700/50;
+  }
+
+  .ryder-table tbody tr:last-child {
+    @apply border-b-0;
+  }
+
   .hpContent h2 {
     @apply flex p-3 items-center mt-0 mb-2 text-3xl uppercase text-neutral-100 bg-gradient-to-r from-slate-700 to-slate-500;
   }
@@ -310,19 +407,19 @@
     }
     .main-menu-ul > li {
       @apply border-b md:border-b-0;
-      @apply border-sky-800 dark:border-sky-600;
-      @apply text-sky-800 dark:text-sky-100;
+      @apply border-ryder-brand-800 dark:border-ryder-brand-600;
+      @apply text-ryder-brand-800 dark:text-ryder-brand-100;
     }
     .main-menu-ul li .active,
     .main-menu-ul li .ancestor  {
-      @apply text-lime-800 dark:text-lime-300;
+      @apply text-ryder-brand-alt-800 dark:text-ryder-brand-alt-300;
     }
     .main-menu-child-ul {
       @apply p-2;
       @apply bg-neutral-100 dark:bg-neutral-700 rounded-lg ring-1 ring-black/5;
     }
     .main-menu-child-ul > li {
-      @apply border-b border-sky-200 dark:border-sky-700;
+      @apply border-b border-ryder-brand-200 dark:border-ryder-brand-700;
       @apply last:border-b-0;
     }
     .child-nav-container {
@@ -350,17 +447,17 @@
     .main-menu-child-ul > li > a {
       @apply transition-colors duration-150 ease-in-out rounded px-2 py-1;
       @apply inline-block w-full;
-      @apply dark:text-sky-100;
+      @apply dark:text-ryder-brand-100;
     }
     .main-menu-ul > li > a:hover,
     .child-nav-label:hover,
     .main-menu-child-ul > li > a:hover {
-      @apply text-sky-600 dark:text-sky-100 bg-neutral-300 dark:bg-neutral-600;
+      @apply text-ryder-brand-600 dark:text-ryder-brand-100 bg-neutral-300 dark:bg-neutral-600;
     }
     .main-menu-ul > li > a:focus-visible,
     .child-nav-label:focus-visible,
     .main-menu-child-ul > li > a:focus-visible {
-      @apply outline-2 outline-offset-2 outline-sky-500;
+      @apply outline-2 outline-offset-2 outline-ryder-brand-500;
     }
   }
   .footer-menu-nav {
@@ -525,8 +622,8 @@ img {
     background-clip: unset;
     -webkit-background-clip: unset;
     color: inherit;
-    @apply border-sky-400 bg-sky-50 text-inherit;
-    @apply dark:border-sky-600 dark:bg-neutral-800;
+    @apply border-ryder-brand-400 bg-ryder-brand-50 text-inherit;
+    @apply dark:border-ryder-brand-600 dark:bg-neutral-800;
     padding: 0.75em 1em;
     margin-top: 1em;
     margin-bottom: 1em;

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -25,8 +25,8 @@ Decision: name the roles, keep the values.
 |---|---|---|
 | `--ryder-brand` | sky-800 `#075985` | logo word 1, nav link, meta icons, blockquote rule |
 | `--ryder-brand-alt` | lime-800 `#3f6212` | logo word 2, active nav |
-| `--ryder-accent` | rose-500 `#f43f5e` | aside icons, tag chips, tag cloud, header edge, CTA ring |
-| `--ryder-chrome-from` / `-to` | slate-900 → slate-700 | header and footer gradient |
+| `--ryder-accent` | rose-500 `#f43f5e` | aside icons, tag chips, tag cloud, CTA ring |
+| `--ryder-chrome-from` / `-to` | slate-900 → slate-700 | *declared only* — the header/footer gradients come from `twClasses`, so nothing in the theme reads these |
 
 Rose won the accent slot because it was already doing the job in the one place
 accent colour is structural — the article aside, where `.aside-*-icon` and the
@@ -73,7 +73,12 @@ fork. Colour follows the pattern rather than inventing a second one.
 ## 3. Tokens are for partial internals only
 
 The default `twClasses` strings shipped in `hugo.toml` stay literal
-(`border-b border-fuchsia-600`, not `border-b border-ryder-accent`).
+(`border-b border-rose-500`, not `border-b border-ryder-accent-500`).
+
+The header edge is the one accent role that is therefore **not** token-driven:
+rose-500 is the accent's value, but repointing `--ryder-accent` does not move it.
+That is deliberate, and it is why the §1 table above lists the edge under the
+header rather than the accent.
 
 Those strings are quoted in the docs and have been copied into users' own
 configs. If a shipped default starts referencing `ryder-*` while a user's

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -1,0 +1,126 @@
+# Design decisions
+
+Durable record of *why* Ryder's visual system is the way it is. Component
+documentation lives in the exampleSite (`/docs/design-system/`) and is generated
+from the live theme; this file holds the reasoning that page can't carry.
+
+Maintainer-facing. Not published by the exampleSite build.
+
+---
+
+## 1. The palette is stock Tailwind, and that was a problem
+
+`tailwind.preset.js` adds no colors. Ryder's palette was therefore whatever
+each partial reached for, and by v0.3.x that had grown to six accent families:
+sky, lime, rose, fuchsia, yellow, and a green/amber pair in the CTA variants.
+
+Only two of those were ever load-bearing. **Sky and lime are brand** — they come
+from the logo, and the nav's default/active states encode them. Everything else
+was incidental: fuchsia edged the header because it looked good against slate,
+yellow bordered the tag cloud for no traceable reason.
+
+Decision: name the roles, keep the values.
+
+| Token | Value | Role |
+|---|---|---|
+| `--ryder-brand` | sky-800 `#075985` | logo word 1, nav link, meta icons, blockquote rule |
+| `--ryder-brand-alt` | lime-800 `#3f6212` | logo word 2, active nav |
+| `--ryder-accent` | rose-500 `#f43f5e` | aside icons, tag chips, tag cloud, header edge, CTA ring |
+| `--ryder-chrome-from` / `-to` | slate-900 → slate-700 | header and footer gradient |
+
+Rose won the accent slot because it was already doing the job in the one place
+accent colour is structural — the article aside, where `.aside-*-icon` and the
+tag chips establish it. Fuchsia and yellow were the outliers, so they moved.
+
+Deliberately **not** tokenized:
+
+- **neutral-100/200/300/700/800/900** — surfaces, not brand. A site that
+  repoints these is choosing a different theme, not configuring this one.
+- **slate-500** meta labels, **slate-200/80** card borders — structural greys.
+- **The alert 50/300/800 hue triples.** Yellow in `alert.html` is *semantic
+  warning*, not decoration. Blue/green/yellow/red carry meaning that survives
+  rebranding; routing them through brand tokens would destroy it.
+- **Amazon yellow and Spotify green** in the CTA variants. These match the
+  platforms they link to. They are not Ryder's colours to change, and they
+  should never be borrowed for a generic button.
+
+## 2. Tokens are RGB channels, not hex
+
+```css
+--ryder-accent: 244 63 94;   /* not #f43f5e */
+```
+
+```js
+accent: 'rgb(var(--ryder-accent) / <alpha-value>)'
+```
+
+A hex value inside `var()` works for `text-`, `bg-`, and `border-`, then
+silently fails on every opacity modifier — `border-ryder-accent/80` produces
+nothing, with no build error. Ryder leans on those modifiers heavily: the card
+borders are `/80`, the aside dark states `/40`, the share-button fills `/88`.
+Channels plus `<alpha-value>` keep them working.
+
+The cost is that config overrides must be supplied as channel triplets. That is
+an unusual thing to ask of a config file, and it is documented in
+`/docs/css-overrides/`. We accepted it rather than adding hex-to-channel
+conversion in a Hugo template, which would have put string parsing on every
+page render to save users one lookup.
+
+Precedent: `--ryder-font-family` already worked exactly this way — a CSS custom
+property the preset reads, so `params.fonts.family` can repoint it without a
+fork. Colour follows the pattern rather than inventing a second one.
+
+## 3. Tokens are for partial internals only
+
+The default `twClasses` strings shipped in `hugo.toml` stay literal
+(`border-b border-fuchsia-600`, not `border-b border-ryder-accent`).
+
+Those strings are quoted in the docs and have been copied into users' own
+configs. If a shipped default starts referencing `ryder-*` while a user's
+override doesn't, they get half a palette — the worst kind of upgrade, because
+it looks like a theme bug rather than a config mismatch.
+
+So: `@apply` rules in `main.css` and hardcoded classes inside partials migrate.
+Anything a user can override stays literal, and the token layer is the *better*
+override path offered alongside, not a replacement.
+
+Corollary: `bg-fuchsia-900/40` in the `navClass` docs and E2E test is a
+user-supplied example demonstrating arbitrary classes. It is not theme styling
+and was left alone.
+
+## 4. `legacyAccents` exists, and should eventually go
+
+Moving the tag cloud and header edge to accent is the only change in the token
+work that alters pixels. `params.colors.legacyAccents = true` restores yellow
+and fuchsia for sites that had built around them.
+
+It is a migration aid with a shelf life. Remove it at the next major.
+
+## 5. Components the theme was missing
+
+Three gaps meant every consuming site invented its own:
+
+- **Form fields.** `ryderForm` already handled submit, status booleans, and the
+  `_gotcha` honeypot — only the visual layer was absent, so sites shipped
+  unstyled inputs next to styled buttons.
+- **Tables.** `@tailwindcss/typography` owns tables inside `prose` and they
+  cannot be restyled from within. The wrapper needs `not-prose`; there was no
+  way to get a themed table without one.
+- **Empty states.** `menu.html` already knew how to hide a section with no
+  content via `hideIfEmptyData`. The list page didn't, so an empty section
+  rendered as a blank page with pagination.
+
+All three were built only from values already in the theme — no new colours,
+radii, or shadows entered the system to add them.
+
+## 6. Documentation is generated, not written
+
+`/docs/design-system/` renders the real partials. Previews *are* the live
+components, so the page cannot drift when a partial changes, and it inherits
+dark mode, the TOC, and the aside for free.
+
+The alternative — a hand-maintained page of static markup — is wrong the first
+time someone touches a partial, and wrong invisibly. Token values on that page
+come from `data/design-system.json`, so a value exists in exactly one place.
+
+What generation can't capture is this file: the reasoning. Keep them separate.

--- a/docs/migration/v0.4.0.md
+++ b/docs/migration/v0.4.0.md
@@ -57,7 +57,7 @@ repoint the palette without overriding class strings one at a time:
 [params.colors]
   brand     = "12 74 110"   # sky-900  — logo word 1, nav, meta icons, blockquote
   brand-alt = "54 83 20"    # lime-900 — logo word 2, active nav
-  accent    = "217 70 239"  # fuchsia-500 — aside icons, tag chips, tag cloud, CTA ring
+  accent    = "217 70 239"  # fuchsia-500 — aside icons, tag chips, tag cloud
 ```
 
 **Values are RGB channel triplets, not hex.** `"244 63 94"`, not `"#f43f5e"`. A
@@ -67,10 +67,17 @@ naming the key.
 
 Each of `brand`, `brand-alt`, and `accent` also carries a full `50`–`950` ramp
 (`accent-300`, `brand-700`, …) because the theme uses more than one shade of
-each. Setting the bare token moves that family's canonical shade; set individual
-steps to move the rest. Full reference: `/docs/css-overrides/#color-tokens`.
+each. Setting the bare token moves **one** step — `brand`→`brand-800`,
+`brand-alt`→`brand-alt-800`, `accent`→`accent-500` — and leaves the rest at
+their defaults. Notably, setting `accent` alone leaves the default CTA's
+`accent-600` border and `accent-300` focus ring rose. Set every step you need;
+full reference: `/docs/css-overrides/#color-tokens`.
 
-Tokens are also usable as ordinary Tailwind classes anywhere you write one,
+`chrome-from` and `chrome-to` are accepted, but **nothing in the theme reads
+them** — the header and footer gradients come from `twClasses`, which stays
+literal. They are there for your own class strings, not as a chrome override.
+
+Tokens are usable as ordinary Tailwind classes anywhere you write one,
 including in `twClasses`: `text-ryder-brand`, `bg-ryder-accent-50`,
 `border-ryder-brand-alt-800`, `from-ryder-chrome-from`, `ring-ryder-accent-300/80`.
 

--- a/docs/migration/v0.4.0.md
+++ b/docs/migration/v0.4.0.md
@@ -1,0 +1,118 @@
+# Migrating to v0.4.0
+
+Minor release. Two things change for existing sites: **one visual change** (the
+accent color), and **one new capability** (the `--ryder-*` color token layer).
+Everything else is additive.
+
+If you do nothing, the only difference you will see is that yellow and fuchsia
+accents are now rose. One config flag restores them.
+
+---
+
+## 1. Accent consolidation — the visual change
+
+Through v0.3.x the theme reached for six accent families: sky, lime, rose,
+fuchsia, yellow, plus the green/amber CTA variants. Two of those were doing real
+work (sky and lime are the logo, and the nav encodes them); rose was structural
+in the article aside. Fuchsia and yellow were incidental.
+
+v0.4.0 moves them onto the accent:
+
+| Element | v0.3.x | v0.4.0 |
+|---|---|---|
+| Tag cloud chip border / hover / focus ring | yellow-500 / 600 / 300 | accent 500 / 600 / 300 |
+| Default CTA button border / hover / ring | fuchsia-600 / 500 / 300 | accent 600 / 500 / 300 |
+
+The tag cloud's lime gradient is unchanged — it reads as brand, and it is the
+chip's fill rather than its accent.
+
+### Restoring the old colors
+
+```toml
+[params.colors]
+  legacyAccents = true
+```
+
+This is a migration aid, not a permanent option. It will be removed at the next
+major — see `docs/design-decisions.md` §4.
+
+### What `legacyAccents` does not cover
+
+The header's bottom edge (`border-b border-fuchsia-600`) arrives through
+**your** `[params.twClasses] headerBackgroundFrameOuter`, not through theme
+internals, so no theme flag can reach it. Two cases:
+
+- **You set `headerBackgroundFrameOuter` yourself.** Nothing changed. Your
+  string is still your string. Update the border class if you want the new
+  accent.
+- **You copied the exampleSite default.** The shipped default is now
+  `border-b border-rose-500`. Copy it again, or keep fuchsia — both are valid.
+
+## 2. Color tokens — the new capability
+
+The theme's colors now resolve through CSS custom properties, so you can
+repoint the palette without overriding class strings one at a time:
+
+```toml
+[params.colors]
+  brand     = "12 74 110"   # sky-900  — logo word 1, nav, meta icons, blockquote
+  brand-alt = "54 83 20"    # lime-900 — logo word 2, active nav
+  accent    = "217 70 239"  # fuchsia-500 — aside icons, tag chips, tag cloud, CTA ring
+```
+
+**Values are RGB channel triplets, not hex.** `"244 63 94"`, not `"#f43f5e"`. A
+hex inside `var()` silently breaks every opacity modifier, and the theme uses
+those throughout. A value in any other format is ignored with a build warning
+naming the key.
+
+Each of `brand`, `brand-alt`, and `accent` also carries a full `50`–`950` ramp
+(`accent-300`, `brand-700`, …) because the theme uses more than one shade of
+each. Setting the bare token moves that family's canonical shade; set individual
+steps to move the rest. Full reference: `/docs/css-overrides/#color-tokens`.
+
+Tokens are also usable as ordinary Tailwind classes anywhere you write one,
+including in `twClasses`: `text-ryder-brand`, `bg-ryder-accent-50`,
+`border-ryder-brand-alt-800`, `from-ryder-chrome-from`, `ring-ryder-accent-300/80`.
+
+### Nothing is required of you
+
+The theme ships defaults identical to the previous hardcoded values, so an
+existing site renders the same whether or not it sets `[params.colors]`.
+
+### If you maintain a fork or a heavily customized site
+
+Theme-internal classes were renamed as a pure rename — `text-sky-700` became
+`text-ryder-brand-700`, and so on across `assets/css/main.css`, `logo.html`, and
+`header.html`. No shade changed. If you shadow any of those files, your copies
+still work; they just don't follow `[params.colors]` until you rename them too.
+
+Class strings in `hugo.toml` were deliberately **not** migrated. See
+`docs/design-decisions.md` §3 for why.
+
+## 3. New components
+
+Three additions, all opt-in:
+
+- **`partials/utils/form-field.html`** — a labelled, themed form control
+  (`text`-like inputs, `textarea`, and `submit`). The form engine, `ryderForm`,
+  already existed; this is the visual layer. See README > Form fields.
+- **`table-wrapper` shortcode** — wraps a Markdown table in a themed shell that
+  scrolls horizontally on mobile instead of pushing the page sideways.
+- **Empty state** — `layouts/_default/list.html` now renders a message and a
+  link home when a section's paginator yields nothing, instead of a blank page
+  with a dead pager. Strings come from `i18n/` (`emptyListTitle`,
+  `emptyListBody`); override them there if you want different words.
+
+## 4. Icons
+
+No action needed. `fa-signs-post` and `fa-circle-check`, used by the empty
+state, were already in the theme's tree-shaken Font Awesome set.
+
+---
+
+## Checklist
+
+- [ ] Build and look at your tag cloud and CTA buttons. Happy with rose? Done.
+- [ ] Not happy? Set `params.colors.legacyAccents = true`.
+- [ ] Check your header's bottom border — it is yours, and unchanged.
+- [ ] Optional: set `[params.colors]` to repoint the palette (channels, not hex).

--- a/exampleSite/config/_default/hugo.toml
+++ b/exampleSite/config/_default/hugo.toml
@@ -133,7 +133,15 @@ themesDir= "../../"
     googleFontsFamily = "Titillium+Web:wght@400;600;700"
 
   [params.twClasses]
-    headerBackgroundFrameOuter = "bg-gradient-to-r from-slate-900 to-slate-700 border-b border-fuchsia-600 text-neutral-100"
+    # The bottom border was border-fuchsia-600 through v0.3.x. v0.4.0 moved the
+    # header edge onto the accent (rose) so the theme has one accent instead of
+    # six. It stays a literal Tailwind class rather than border-ryder-accent-500:
+    # this string is a *default a user copies into their own config*, and a
+    # default that references the token layer while their copy doesn't leaves
+    # them with half a palette. `params.colors.legacyAccents` cannot reach this
+    # value either — it is config, not theme internals. See
+    # docs/design-decisions.md §3 and docs/migration/v0.4.0.md.
+    headerBackgroundFrameOuter = "bg-gradient-to-r from-slate-900 to-slate-700 border-b border-rose-500 text-neutral-100"
     headerBackgroundFrameInner = "h-[240px] sm:h-[400px] bg-cover bg-center sm:bg-[center_30%]"
     headerBackgroundImage = "images/hyder_theme_header.webp"
     # Body classes, v0.2.5 item 2.7. Stated explicitly here rather than left to

--- a/exampleSite/content/docs/css-overrides/index.md
+++ b/exampleSite/content/docs/css-overrides/index.md
@@ -41,7 +41,7 @@ palette without overriding a single class string. Four semantic roles:
 | `brand` | `7 89 133` | sky-800 | logo word 1, nav links, article meta icons, blockquote rule |
 | `brand-alt` | `63 98 18` | lime-800 | logo word 2, active nav entry |
 | `accent` | `244 63 94` | rose-500 | aside icons, tag chips, tag cloud, CTA ring |
-| `chrome-from` / `chrome-to` | `15 23 42` / `51 65 85` | slate-900 / slate-700 | header and footer gradient |
+| `chrome-from` / `chrome-to` | `15 23 42` / `51 65 85` | slate-900 / slate-700 | *declared only* — see below |
 
 ```toml
 [params.colors]
@@ -49,6 +49,15 @@ palette without overriding a single class string. Four semantic roles:
   brand-alt = "54 83 20"     # lime-900
   accent    = "217 70 239"   # fuchsia-500
 ```
+
+### `chrome-from` and `chrome-to` are declared, not wired
+
+They exist in the preset so you can use `from-ryder-chrome-from` /
+`to-ryder-chrome-to` in your own class strings. **Nothing in the theme reads
+them.** The header and footer gradients arrive through
+`twClasses.headerBackgroundFrameOuter`, which stays a literal Tailwind string
+for the reason given below — so setting `chrome-from` does not retint your
+header. Change the gradient in `headerBackgroundFrameOuter` itself.
 
 ### Values are RGB channels, not hex
 
@@ -64,20 +73,31 @@ To convert: `#f43f5e` → `f4`=244, `3f`=63, `5e`=94 → `"244 63 94"`.
 ### The ramp
 
 Each of `brand`, `brand-alt`, and `accent` carries a full 50–950 ramp, because
-the theme uses more than one shade of each — the nav alone spans sky-100 through
-sky-800. Setting the bare token moves that family's canonical shade (`brand` is
-sky-800, `accent` is rose-500) along with everything keyed to it. Set individual
-steps when you need the rest to follow:
+the theme uses more than one shade of each — the nav alone spans `brand-100`
+through `brand-800`.
+
+Setting the bare token moves **only that family's canonical step**, and the
+canonical step differs per family: `brand` aliases `brand-800`, `brand-alt`
+aliases `brand-alt-800`, `accent` aliases `accent-500`. Every other step keeps
+its default.
+
+That matters more than it sounds. The default CTA button uses
+`accent-600` / `accent-500` / `accent-300` for its border, hover, and focus
+ring — so setting `accent` alone moves the hover and leaves the border and ring
+rose. **Set every step a component actually uses:**
 
 ```toml
 [params.colors]
-  accent     = "217 70 239"   # moves ryder-accent and ryder-accent-500
-  accent-50  = "253 244 255"  # the tag chip's light fill
-  accent-300 = "240 171 252"  # the tag chip's border
-  accent-950 = "74 4 78"      # the tag chip's dark-mode fill
+  accent     = "217 70 239"   # ryder-accent + ryder-accent-500 (chip hover, aside icons)
+  accent-50  = "253 244 255"  # tag chip light fill
+  accent-300 = "240 171 252"  # tag chip border, CTA focus ring
+  accent-600 = "192 38 211"   # CTA border, tag chip hover border
+  accent-950 = "74 4 78"      # tag chip dark-mode fill
 ```
 
-Anything you leave unset keeps the theme default, so a partial override is safe.
+Anything you leave unset keeps the theme default, so a partial override is safe
+— it just won't be a complete one. Grep the theme for the family you're
+repointing (`rg 'ryder-accent-' layouts assets/css`) to see every step in use.
 
 ### Using the tokens in your own classes
 

--- a/exampleSite/content/docs/css-overrides/index.md
+++ b/exampleSite/content/docs/css-overrides/index.md
@@ -22,7 +22,84 @@ Control the header image, footer background, card colors, and border accents —
 
 The Ryder theme reads TailwindCSS class strings from your config and applies them directly to layout elements. This lets you customize colors, backgrounds, gradients, and spacing using any Tailwind utility class — including [arbitrary values](https://tailwindcss.com/docs/adding-custom-styles#using-arbitrary-values) for things like custom image URLs or pixel measurements.
 
-All overrides live under `[params.twClasses]` in your `hugo.toml`.
+Class-string overrides live under `[params.twClasses]` in your `hugo.toml`. They
+are the escape hatch — total control, one element at a time. For color, reach
+for the token layer below first: it repoints the whole theme at once, including
+the parts no `twClasses` param exposes.
+
+---
+
+## Color tokens
+
+*New in v0.4.0.*
+
+The theme's colors resolve through CSS custom properties, so you can repoint the
+palette without overriding a single class string. Four semantic roles:
+
+| Token | Default | Tailwind | Used by |
+|---|---|---|---|
+| `brand` | `7 89 133` | sky-800 | logo word 1, nav links, article meta icons, blockquote rule |
+| `brand-alt` | `63 98 18` | lime-800 | logo word 2, active nav entry |
+| `accent` | `244 63 94` | rose-500 | aside icons, tag chips, tag cloud, CTA ring |
+| `chrome-from` / `chrome-to` | `15 23 42` / `51 65 85` | slate-900 / slate-700 | header and footer gradient |
+
+```toml
+[params.colors]
+  brand     = "12 74 110"    # sky-900
+  brand-alt = "54 83 20"     # lime-900
+  accent    = "217 70 239"   # fuchsia-500
+```
+
+### Values are RGB channels, not hex
+
+`"244 63 94"`, **not** `"#f43f5e"`. This is not a style preference. A hex value
+inside `var()` works for `text-`, `bg-`, and `border-`, then silently produces
+nothing for every opacity modifier — `border-ryder-accent-300/80`,
+`dark:bg-ryder-accent-950/40` — with no build error to tell you. Space-separated
+channels interpolate with Tailwind's `<alpha-value>` and keep the modifiers
+working. A value in any other format is ignored with a build warning.
+
+To convert: `#f43f5e` → `f4`=244, `3f`=63, `5e`=94 → `"244 63 94"`.
+
+### The ramp
+
+Each of `brand`, `brand-alt`, and `accent` carries a full 50–950 ramp, because
+the theme uses more than one shade of each — the nav alone spans sky-100 through
+sky-800. Setting the bare token moves that family's canonical shade (`brand` is
+sky-800, `accent` is rose-500) along with everything keyed to it. Set individual
+steps when you need the rest to follow:
+
+```toml
+[params.colors]
+  accent     = "217 70 239"   # moves ryder-accent and ryder-accent-500
+  accent-50  = "253 244 255"  # the tag chip's light fill
+  accent-300 = "240 171 252"  # the tag chip's border
+  accent-950 = "74 4 78"      # the tag chip's dark-mode fill
+```
+
+Anything you leave unset keeps the theme default, so a partial override is safe.
+
+### Using the tokens in your own classes
+
+The preset exposes them as ordinary Tailwind colors, usable anywhere a class
+string is accepted — including `twClasses`:
+
+```
+text-ryder-brand        bg-ryder-accent-50    border-ryder-brand-alt-800
+from-ryder-chrome-from  to-ryder-chrome-to    ring-ryder-accent-300/80
+```
+
+Note that `twClasses` values you set are literal strings under your control; the
+theme's own shipped defaults deliberately stay on plain Tailwind classes so a
+config copied from the docs never depends on the token layer.
+
+### What is not tokenized
+
+Surfaces (`neutral-*`), structural greys (`slate-500` labels, `slate-200/80`
+borders), the alert color triples, and the Amazon/Spotify button fills. The
+alert colors carry *meaning* — yellow is "warning", not decoration — and the
+platform fills belong to those platforms. Repointing either would be a bug, not
+a theme.
 
 ---
 
@@ -73,7 +150,7 @@ The header uses two layers: an outer frame (background color, border, text color
 
 ```toml
 [params.twClasses]
-  headerBackgroundFrameOuter = "bg-gradient-to-r from-slate-900 to-slate-700 border-b border-fuchsia-600 text-neutral-100"
+  headerBackgroundFrameOuter = "bg-gradient-to-r from-slate-900 to-slate-700 border-b border-rose-500 text-neutral-100"
   headerBackgroundFrameInner = "bg-[url('/images/your-header-photo.jpg')] h-[350px] bg-cover bg-[center_40%]"
 ```
 
@@ -85,7 +162,7 @@ Controls the header's outermost wrapper — background color or gradient, border
 |---|---|
 | `bg-slate-900` | Solid dark background |
 | `bg-gradient-to-r from-slate-900 to-slate-700` | Horizontal gradient |
-| `border-b border-fuchsia-600` | Bottom border in accent color |
+| `border-b border-rose-500` | Bottom border in accent color |
 | `text-neutral-100` | Light text for dark backgrounds |
 
 ### `headerBackgroundFrameInner`
@@ -153,10 +230,17 @@ Override on a per-section or per-category basis by adding a `cascade` block to t
 Border colors are set as part of `headerBackgroundFrameOuter`. The `border-b` and `border-{color}` classes together control the bottom border line:
 
 ```toml
-headerBackgroundFrameOuter = "... border-b border-fuchsia-600 ..."
+headerBackgroundFrameOuter = "... border-b border-rose-500 ..."
 ```
 
-Change `border-fuchsia-600` to any Tailwind color class. For no border, omit both `border-b` and the color class.
+Change `border-rose-500` to any Tailwind color class. For no border, omit both `border-b` and the color class.
+
+This was `border-fuchsia-600` through v0.3.x. v0.4.0 moved the header edge onto
+the theme accent — see [Color tokens](#color-tokens) below, and the [v0.4.0
+migration guide](https://github.com/arts-link/ryder/blob/main/docs/migration/v0.4.0.md).
+Because this is your config rather than theme internals, `legacyAccents` does
+not reach it: if you already set `headerBackgroundFrameOuter` yourself, nothing
+changed for you.
 
 ---
 

--- a/exampleSite/package-lock.json
+++ b/exampleSite/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ryder-example-site",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ryder-example-site",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@alpinejs/csp": "^3.15.12",

--- a/exampleSite/package.json
+++ b/exampleSite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ryder-example-site",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Example site for the Ryder Hugo theme",
   "author": "Ben Strawbridge",
   "license": "MIT",

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -9,3 +9,9 @@ other = "Home"
 
 [toc]
 other = "Inhaltsverzeichnis"
+
+[emptyListTitle]
+other = "Hier ist noch nichts"
+
+[emptyListBody]
+other = "In diesem Bereich gibt es derzeit keine Beiträge. Schauen Sie bald wieder vorbei."

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -9,3 +9,9 @@ other = "Home"
 
 [toc]
 other = "Table of Contents"
+
+[emptyListTitle]
+other = "Nothing here yet"
+
+[emptyListBody]
+other = "This section has no posts to show right now. Check back soon."

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -9,3 +9,9 @@ other = "Accueil"
 
 [toc]
 other = "Table des matières"
+
+[emptyListTitle]
+other = "Rien ici pour l'instant"
+
+[emptyListBody]
+other = "Cette section ne contient aucun article pour le moment. Revenez bientôt."

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -16,20 +16,26 @@
       {{- partial "taxonomy-cloud.html" . -}}
     </div>
   {{- else }}
+    {{- $myCollection := .Pages -}}
+    {{- if eq .Params.listRecursive true -}}
+      {{- $myCollection = .RegularPagesRecursive -}}
+    {{- end -}}
+    {{- $sortBy := .Param "listSortBy" | default "Date" }}
+    {{- $sortOrder := .Param "listSortOrder" | default "desc" }}
+    {{- $paginator := .Paginate (sort $myCollection $sortBy $sortOrder) }}
+    {{- if eq (len $paginator.Pages) 0 -}}
+      {{- /* Nothing to page through. Rendering the grid and the pagination
+             controls anyway leaves a blank page with a dead pager on it. */ -}}
+      {{- partial "utils/empty-state.html" . -}}
+    {{- else -}}
     <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-6 m-2">
-      {{- $myCollection := .Pages -}}
-      {{- if eq .Params.listRecursive true -}}
-        {{- $myCollection = .RegularPagesRecursive -}}
-      {{- end -}}
-      {{- $sortBy := .Param "listSortBy" | default "Date" }}
-      {{- $sortOrder := .Param "listSortOrder" | default "desc" }}
-      {{- $paginator := .Paginate (sort $myCollection $sortBy $sortOrder) }}
       {{ $listCardType := .Param "listCardType" | default "-category-color" }}
       {{- range $paginator.Pages -}}
         {{- partial (printf "card%s.html" $listCardType) . -}}
       {{- end -}}
     </div>
     {{- template "_internal/pagination.html" . -}}
+    {{- end -}}
   {{- end -}}
 </div>
 {{- end -}}

--- a/layouts/partials/cta-button.html
+++ b/layouts/partials/cta-button.html
@@ -12,7 +12,7 @@ for example::
 */}}
 {{ $button_type := .button_type }}
 {{ $button_label := default "Go!" .button_label }}
-{{ $button_class := default "bg-slate-800 text-neutral-100 font-medium py-2 mt-4 px-4 rounded-full border-2 border-fuchsia-600 hover:bg-slate-700 hover:border-fuchsia-500 focus:outline-none focus:ring-2 focus:ring-fuchsia-300 no-underline inline-block text-center break-words dark:bg-slate-700 dark:hover:bg-slate-600" .button_class }}
+{{ $button_class := default (partial "utils/cta-class.html" .) .button_class }}
 {{ $button_relref := .button_relref }}
 {{ $button_href := .button_href }}
 {{ $button_icon := .button_icon }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -30,6 +30,9 @@
   {{- partial "head/csp.html" . }}
 {{- partialCached "head/fonts.html" . }}
 {{- partial "head/css.html" . }}
+{{- /* After head/css.html on purpose: both write :root, and the later block
+       wins. See head/colors.html. */ -}}
+{{- partialCached "head/colors.html" . }}
 {{- partial "head/js.html" . }}
 {{- if hugo.IsProduction -}}
   {{ partial "analytics.html" . }}

--- a/layouts/partials/head/colors.html
+++ b/layouts/partials/head/colors.html
@@ -16,7 +16,7 @@ per page.
       brand-alt  = "54 83 20"
       accent     = "217 70 239"   # also moves ryder-accent-500
       accent-600 = "192 38 211"
-      chrome-from = "24 24 27"
+      chrome-from = "24 24 27"    # declared only — see below
       chrome-to   = "63 63 70"
 
 VALUES ARE RGB CHANNELS, not hex: "244 63 94", not "#f43f5e". A hex inside
@@ -28,6 +28,16 @@ rather than half-applied. See README > Color tokens.
 Recognised keys: brand, brand-alt, accent (each optionally suffixed with a ramp
 step 50-950), chrome-from, chrome-to. `legacyAccents` also lives under
 [params.colors] but is a behavior flag, not a color, and is skipped here.
+
+Two things the docs have to keep saying, because neither is guessable:
+
+  - chrome-from/chrome-to are accepted and emitted, but NOTHING in the theme
+    reads them. The header and footer gradients come from twClasses, which
+    stays literal by design. They exist for use in a site's own class strings.
+  - The bare token aliases one ramp step, and which one differs per family
+    (brand -> 800, brand-alt -> 800, accent -> 500). Setting `accent` alone
+    leaves accent-600 and accent-300 — both used by the default CTA — at their
+    defaults.
 */ -}}
 {{- $colors := site.Params.colors | default dict -}}
 {{- $steps := slice "50" "100" "200" "300" "400" "500" "600" "700" "800" "900" "950" -}}

--- a/layouts/partials/head/colors.html
+++ b/layouts/partials/head/colors.html
@@ -1,0 +1,55 @@
+{{- /*
+Semantic color token overrides — the [params.colors] half of the token layer
+introduced in v0.4.0. Follows the --ryder-font-family precedent in
+head/fonts.html: the theme ships defaults in assets/css/main.css's :root block,
+and this partial writes a :root override for the keys a site actually sets.
+
+ORDERING: head.html calls this AFTER head/css.html. Both blocks target :root
+with equal specificity, so the later one wins; moving this ahead of the
+stylesheet would let the theme's defaults silently override a site's config.
+
+Site-level only: called via partialCached (see head.html), so this cannot vary
+per page.
+
+    [params.colors]
+      brand      = "12 74 110"    # sky-900 — also moves ryder-brand-800
+      brand-alt  = "54 83 20"
+      accent     = "217 70 239"   # also moves ryder-accent-500
+      accent-600 = "192 38 211"
+      chrome-from = "24 24 27"
+      chrome-to   = "63 63 70"
+
+VALUES ARE RGB CHANNELS, not hex: "244 63 94", not "#f43f5e". A hex inside
+var() works for text-/bg-/border- but silently breaks every opacity modifier,
+and the theme uses those throughout. There is deliberately no hex-to-channel
+conversion here — the format is a requirement, and a wrong one is warned about
+rather than half-applied. See README > Color tokens.
+
+Recognised keys: brand, brand-alt, accent (each optionally suffixed with a ramp
+step 50-950), chrome-from, chrome-to. `legacyAccents` also lives under
+[params.colors] but is a behavior flag, not a color, and is skipped here.
+*/ -}}
+{{- $colors := site.Params.colors | default dict -}}
+{{- $steps := slice "50" "100" "200" "300" "400" "500" "600" "700" "800" "900" "950" -}}
+{{- $allowed := slice "chrome-from" "chrome-to" -}}
+{{- range $family := slice "brand" "brand-alt" "accent" -}}
+  {{- $allowed = $allowed | append $family -}}
+  {{- range $steps -}}
+    {{- $allowed = $allowed | append (printf "%s-%s" $family .) -}}
+  {{- end -}}
+{{- end -}}
+{{- $decls := slice -}}
+{{- range $key, $value := $colors -}}
+  {{- if ne $key "legacyaccents" -}}
+    {{- if not (in $allowed $key) -}}
+      {{- warnf "params.colors: unknown key %q — expected one of brand, brand-alt, accent (optionally -50 through -950), chrome-from, chrome-to, or legacyAccents" $key -}}
+    {{- else if not (findRE `^[0-9]{1,3} [0-9]{1,3} [0-9]{1,3}$` (printf "%v" $value)) -}}
+      {{- warnf "params.colors.%s = %q is not an RGB channel triplet — use %q, not a hex value; ignoring" $key $value "244 63 94" -}}
+    {{- else -}}
+      {{- $decls = $decls | append (printf "--ryder-%s:%v;" $key $value) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- with $decls }}
+<style>:root{ {{- delimit . "" | safeCSS -}} }</style>
+{{- end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -46,7 +46,7 @@ By default it will have a background gradient in cayan.
               {{/*  <input id="nav-toggle" type="checkbox" class="hidden" />  */}}
               <button
                   aria-label="Toggle Menu"
-                  class="relative z-50 cursor-pointer md:hidden p-3 text-sky-700 bg-neutral-200 rounded-full "
+                  class="relative z-50 cursor-pointer md:hidden p-3 text-ryder-brand-700 bg-neutral-200 rounded-full "
                   @click="openMenu = ! openMenu">
                   <div x-bind:class="openMenu ? 'hidden' : 'visible'" class="flex flex-col text-xs"><i class="size-8 text-2xl fas fa-bars"></i></div>
                   <div x-bind:class="openMenu ? 'visible' : 'hidden'" class="flex flex-col text-xs"><i class="size-8 text-2xl fas fa-xmark"></i></div>

--- a/layouts/partials/logo.html
+++ b/layouts/partials/logo.html
@@ -45,11 +45,11 @@
         {{- $lw = split $lw "" -}}
         <h1 class="text-4xl nowrap">
           {{/*  <span class="text-[#17729C]">  */}}
-          <span class="text-sky-800">
+          <span class="text-ryder-brand-800">
             {{- range $k, $v := $fw }}
               {{- $v }}{{- if (eq $k 0) }}<span class="{{- $lettersClass }}" >{{- end }}{{- if (eq $k $fwLen) }}</span >{{- end }}
             {{- end -}}
-          </span ><span class="{{- $lettersClass }}">&nbsp;</span ><span class="text-lime-800">
+          </span ><span class="{{- $lettersClass }}">&nbsp;</span ><span class="text-ryder-brand-alt-800">
             {{- range $k, $v := $lw }}
               {{- $v }}{{- if (eq $k 0) }}<span class="{{- $lettersClass }}" >{{- end }}{{- if (eq $k 10) }}</span >{{- end }}
             {{- end -}}

--- a/layouts/partials/taxonomy-cloud.html
+++ b/layouts/partials/taxonomy-cloud.html
@@ -29,8 +29,17 @@
          {{ $weight := div (sub (math.Log $tagCount) (math.Log $min)) (sub (math.Log $max) (math.Log $min)) }}
          {{ $currentFontSize := (add $smallestFontSize (mul (sub $largestFontSize $smallestFontSize) $weight)) }}
          {{ $baseURL := $.Site.BaseURL }}
+         {{/* The lime gradient stays: it reads as brand-alt, and it is the
+              chip's fill. Only the border/hover/ring move to accent — those
+              were yellow, a sixth accent family with no other use in the
+              theme. `params.colors.legacyAccents = true` restores the yellow;
+              see docs/migration/v0.4.0.md. */}}
          {{ $gradientClass := "bg-gradient-to-r from-lime-400 to-lime-500 text-zinc-900 "}}
-         {{ $classes := "py-2 px-4 rounded-full border-2 border-yellow-500 hover:bg-yellow-500 hover:border-yellow-600 focus:outline-none focus:ring-2 focus:ring-yellow-300 no-underline inline-block text-center break-words "}}
+         {{ $chipAccent := "border-ryder-accent-500 hover:bg-ryder-accent-500 hover:border-ryder-accent-600 focus:ring-ryder-accent-300" }}
+         {{ if (site.Params.colors | default dict).legacyAccents }}
+           {{ $chipAccent = "border-yellow-500 hover:bg-yellow-500 hover:border-yellow-600 focus:ring-yellow-300" }}
+         {{ end }}
+         {{ $classes := printf "py-2 px-4 rounded-full border-2 %s focus:outline-none focus:ring-2 no-underline inline-block text-center break-words " $chipAccent }}
          {{ $headerBackgroundFrameOuter := "" }}
          {{ with $.Site.Param "twClasses.headerBackgroundFrameOuter" }}
            {{ $gradientClass = . }}

--- a/layouts/partials/utils/cta-class.html
+++ b/layouts/partials/utils/cta-class.html
@@ -1,0 +1,22 @@
+{{- /*
+Returns the theme's default CTA button class string.
+
+It lives here rather than inline in cta-button.html because three call sites
+need the same string — the partial, the submit button in utils/form-field.html,
+and (indirectly) the cta-button shortcode — and because the accent portion is
+conditional, so there is exactly one place for that condition to live.
+
+The border/hover/ring were fuchsia through v0.3.x. They are accent as of
+v0.4.0; `params.colors.legacyAccents = true` restores the old fuchsia. See
+docs/migration/v0.4.0.md.
+
+@returns string
+
+@example {{ $class := partial "utils/cta-class.html" . }}
+*/ -}}
+{{- $colors := site.Params.colors | default dict -}}
+{{- $accent := "border-ryder-accent-600 hover:border-ryder-accent-500 focus:ring-ryder-accent-300" -}}
+{{- if $colors.legacyAccents -}}
+  {{- $accent = "border-fuchsia-600 hover:border-fuchsia-500 focus:ring-fuchsia-300" -}}
+{{- end -}}
+{{- return printf "bg-slate-800 text-neutral-100 font-medium py-2 mt-4 px-4 rounded-full border-2 %s hover:bg-slate-700 focus:outline-none focus:ring-2 no-underline inline-block text-center break-words dark:bg-slate-700 dark:hover:bg-slate-600" $accent -}}

--- a/layouts/partials/utils/empty-state.html
+++ b/layouts/partials/utils/empty-state.html
@@ -1,0 +1,33 @@
+{{- /*
+Rendered by layouts/_default/list.html when a section's paginator yields no
+pages — a section that exists and is reachable, but has nothing in it yet.
+
+This is the third of the theme's three answers to "nothing here", and it is
+worth knowing which one you want:
+
+  1. The *menu entry* disappears — `hideIfEmptyData` under the entry's own
+     [menus.<id>.params]. For a section whose absence is the honest signal
+     (a "Press" link with no press behind it is a dead link). See menu.html.
+  2. The *page* stays and explains itself in prose — `dataSource` plus
+     `emptyDataMessage` on a `list-plain` page. See list-plain.html.
+  3. This: a regular list page whose collection is empty. Nothing was
+     configured, so the theme has to say something sensible on its own.
+
+Strings come from i18n so translations get them for free; there is no new
+param, because a site that wants different words should be setting them for
+every language rather than one.
+
+@context {page} The list page.
+*/ -}}
+<div class="m-2 rounded-xl border border-dashed border-slate-300 p-9 text-center dark:border-slate-600">
+  <i class="fa-solid fa-signs-post mb-3 text-4xl text-ryder-accent-500" aria-hidden="true"></i>
+  <p class="m-0 text-lg font-semibold">{{ i18n "emptyListTitle" }}</p>
+  <p class="mt-1 mb-0 text-slate-500 dark:text-slate-400">{{ i18n "emptyListBody" }}</p>
+  <div class="flex justify-center">
+    {{- partial "cta-button.html" (dict
+      "button_label" (i18n "toHomepage")
+      "button_href" site.Home.RelPermalink
+      "button_icon" "fa-solid fa-house mr-2"
+      "page" .) -}}
+  </div>
+</div>

--- a/layouts/partials/utils/form-field.html
+++ b/layouts/partials/utils/form-field.html
@@ -1,0 +1,97 @@
+{{- /*
+A labelled form control, styled to match the theme.
+
+The form *engine* already exists: `ryderForm` in assets/js/main.js handles
+submit, exposes the request state, and swallows the `_gotcha` honeypot — see
+exampleSite/content/docs/forms.md. Only the visual layer was missing, which is
+all this partial is. It emits no Alpine state of its own beyond binding the
+submit button to the engine's `isLoading`.
+
+@context {string}  name         Field name. Required. Also the default id.
+@context {string}  type         Input type: any text-like HTML input type, plus
+                                "textarea" and "submit". Defaults to "text".
+@context {string}  label        Visible label. Defaults to `name`. Ignored for
+                                type "submit", where `label` is the button text.
+@context {string}  placeholder  Optional placeholder.
+@context {bool}    required     Optional; marks the control required and appends
+                                an asterisk to the label.
+@context {string}  id           Optional; defaults to an anchorized `name`.
+@context {string}  value        Optional initial value.
+@context {string}  help         Optional hint rendered under the control.
+@context {string}  autocomplete Optional autocomplete token.
+@context {int}     rows         Textarea rows. Defaults to 4.
+@context {string}  class        Optional extra classes on the control.
+@context {string}  successMessage  type "submit" only; renders an x-show="isSuccess" line.
+@context {string}  errorMessage    type "submit" only; renders an x-show="isError" line.
+                                   Pass "" to bind x-text to the engine's own errorMessage.
+
+@example
+  <form x-data="ryderForm" @submit.prevent="submit"
+        data-form-action="https://api.example.com/subscribe">
+    {{ partial "utils/form-field.html" (dict "name" "email" "type" "email"
+        "label" "Email" "placeholder" "you@example.com" "required" true) }}
+    <input type="text" name="_gotcha" tabindex="-1" autocomplete="off"
+           class="hidden" aria-hidden="true">
+    {{ partial "utils/form-field.html" (dict "type" "submit" "label" "Subscribe"
+        "successMessage" "Thanks!") }}
+  </form>
+
+The status bindings are plain property lookups on purpose. Ryder ships the CSP
+build of Alpine, whose evaluator cannot run a comparison like
+`status === 'success'`; `ryderForm` exposes isIdle/isLoading/isSuccess/isError
+as booleans precisely so x-show has something it can read.
+*/ -}}
+{{- $type := .type | default "text" -}}
+{{- $name := .name | default "" -}}
+{{- $id := .id | default (anchorize (or $name $type)) -}}
+{{- $label := .label | default $name -}}
+{{- $required := .required | default false -}}
+
+{{- if eq $type "submit" -}}
+  {{- $submitClass := .class | default (partial "utils/cta-class.html" .) -}}
+  <div class="flex flex-col items-start gap-2">
+    <button type="submit" class="{{ $submitClass }}" :disabled="isLoading">
+      {{- $label | default "Submit" -}}
+    </button>
+    {{- with .successMessage }}
+    <p id="{{ $id }}-success" class="m-0 text-sm text-slate-700 dark:text-slate-200" x-show="isSuccess" x-cloak>{{ . }}</p>
+    {{- end }}
+    {{- /* An empty errorMessage is meaningful — it defers to whatever the
+           engine put in its own errorMessage property — so this tests for the
+           key's presence, not its truthiness. */ -}}
+    {{- if isset . "errorMessage" }}
+    {{- if .errorMessage }}
+    <p id="{{ $id }}-error" class="m-0 text-sm text-ryder-accent-600 dark:text-ryder-accent-400" x-show="isError" x-cloak>{{ .errorMessage }}</p>
+    {{- else }}
+    <p id="{{ $id }}-error" class="m-0 text-sm text-ryder-accent-600 dark:text-ryder-accent-400" x-show="isError" x-cloak x-text="errorMessage"></p>
+    {{- end }}
+    {{- end }}
+  </div>
+{{- else -}}
+  {{- $controlClass := printf "border border-slate-200/80 rounded-lg px-3 py-2.5 text-base bg-neutral-100 focus:outline-2 focus:outline-offset-2 focus:outline-ryder-brand dark:border-slate-700/70 dark:bg-neutral-800 %s" (.class | default "") -}}
+  <div class="flex flex-col gap-1.5">
+    <label for="{{ $id }}" class="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
+      {{- $label -}}
+      {{- if $required }}<span aria-hidden="true"> *</span>{{ end -}}
+    </label>
+    {{- if eq $type "textarea" }}
+    <textarea id="{{ $id }}" name="{{ $name }}" rows="{{ .rows | default 4 }}"
+      class="{{ $controlClass }}"
+      {{- with .placeholder }} placeholder="{{ . }}"{{ end }}
+      {{- with .autocomplete }} autocomplete="{{ . }}"{{ end }}
+      {{- if $required }} required{{ end }}
+      {{- with .help }} aria-describedby="{{ $id }}-help"{{ end }}>{{ with .value }}{{ . }}{{ end }}</textarea>
+    {{- else }}
+    <input id="{{ $id }}" name="{{ $name }}" type="{{ $type }}"
+      class="{{ $controlClass }}"
+      {{- with .value }} value="{{ . }}"{{ end }}
+      {{- with .placeholder }} placeholder="{{ . }}"{{ end }}
+      {{- with .autocomplete }} autocomplete="{{ . }}"{{ end }}
+      {{- if $required }} required{{ end }}
+      {{- with .help }} aria-describedby="{{ $id }}-help"{{ end }}>
+    {{- end }}
+    {{- with .help }}
+    <p id="{{ $id }}-help" class="m-0 text-sm text-slate-500 dark:text-slate-400">{{ . }}</p>
+    {{- end }}
+  </div>
+{{- end -}}

--- a/layouts/shortcodes/cta-button.html
+++ b/layouts/shortcodes/cta-button.html
@@ -9,7 +9,9 @@ for example::
 >}}
 */}}
 {{ $button_label := default "Go!" (.Get "button_label") }}
-{{ $button_class := default "bg-slate-800 text-neutral-100 font-medium py-2 mt-4 px-4 rounded-full border-2 border-fuchsia-600 hover:bg-slate-700 hover:border-fuchsia-500 focus:outline-none focus:ring-2 focus:ring-fuchsia-300 no-underline inline-block text-center break-words dark:bg-slate-700 dark:hover:bg-slate-600" (.Get "button_class") }}
+{{/* Left empty when unset so cta-button.html applies the one canonical default
+     (utils/cta-class.html) rather than this file carrying a second copy. */}}
+{{ $button_class := .Get "button_class" }}
 {{ $button_type := .Get "button_type" }}
 {{ $button_relref := .Get "button_relref" }}
 {{ $button_href := .Get "button_href" }}

--- a/layouts/shortcodes/table-wrapper.html
+++ b/layouts/shortcodes/table-wrapper.html
@@ -1,0 +1,28 @@
+{{- /*
+Wraps a Markdown table in a themed, horizontally-scrollable shell.
+
+Why a wrapper at all: @tailwindcss/typography owns table styling inside
+`prose`, and those rules cannot be overridden from within — the wrapper has to
+opt out with `not-prose` and re-state the cell styling, which
+`.ryder-table` in assets/css/main.css does. Markdown generates the <table>, so
+there is nowhere to hang a class; the rules are element selectors under the
+shell.
+
+The inner scroll container is what keeps a wide table from pushing the page
+sideways on a phone: the table scrolls, the body does not.
+
+@example
+  {{< table-wrapper >}}
+  | Param | Default | Notes |
+  |---|---|---|
+  | `showDate` | `true` | Show post dates |
+  {{< /table-wrapper >}}
+
+Called with `{{< >}}`, not `{{% %}}` — the inner Markdown is rendered here so
+the shell markup stays outside Goldmark's paragraph handling.
+*/ -}}
+<div class="ryder-table not-prose my-4">
+  <div class="ryder-table-scroll">
+    {{- .Inner | .Page.RenderString (dict "display" "block") -}}
+  </div>
+</div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ryder",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ryder",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "engines": {
         "node": "^22.22.2 || ^24.15.0 || >=26.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ryder",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "A barebones Hugo theme built with TailwindCSS and Alpine.js",
   "author": "Ben Strawbridge",
   "license": "MIT",

--- a/tailwind.preset.js
+++ b/tailwind.preset.js
@@ -38,6 +38,70 @@ module.exports = {
         "header-sunset-mb":
           " url('/images/header-bg/sunset-mission-bay_hu6f04b8530673b6e2cc009e9b6d51ea4d_1824404_1024x768_resize_q100_h2_box.webp')",
       },
+      colors: {
+        // Semantic color tokens. Every value resolves through a CSS custom
+        // property so a site can repoint the palette without forking the
+        // preset -- see head/colors.html and README > Color tokens.
+        //
+        // Channels, not hex: a hex inside var() works for text-/bg-/border-
+        // but silently breaks every opacity modifier, and the theme leans on
+        // those (border-ryder-accent-300/80, dark:bg-ryder-accent-950/40, the
+        // share-button fills at /88). Space-separated RGB channels interpolate
+        // with <alpha-value> and keep the modifiers working.
+        //
+        // Each family carries a full 50-950 ramp so migrating the theme's own
+        // classes is a pure rename with no visual change, and the ramp step
+        // matching the family's canonical shade resolves through the headline
+        // token (--ryder-brand-800 -> var(--ryder-brand)); setting just
+        // --ryder-brand therefore moves both `ryder-brand` and
+        // `ryder-brand-800`. assets/css/main.css holds the default values.
+        ryder: {
+          brand: {
+            DEFAULT: "rgb(var(--ryder-brand) / <alpha-value>)",
+            50: "rgb(var(--ryder-brand-50) / <alpha-value>)",
+            100: "rgb(var(--ryder-brand-100) / <alpha-value>)",
+            200: "rgb(var(--ryder-brand-200) / <alpha-value>)",
+            300: "rgb(var(--ryder-brand-300) / <alpha-value>)",
+            400: "rgb(var(--ryder-brand-400) / <alpha-value>)",
+            500: "rgb(var(--ryder-brand-500) / <alpha-value>)",
+            600: "rgb(var(--ryder-brand-600) / <alpha-value>)",
+            700: "rgb(var(--ryder-brand-700) / <alpha-value>)",
+            800: "rgb(var(--ryder-brand-800) / <alpha-value>)",
+            900: "rgb(var(--ryder-brand-900) / <alpha-value>)",
+            950: "rgb(var(--ryder-brand-950) / <alpha-value>)",
+          },
+          "brand-alt": {
+            DEFAULT: "rgb(var(--ryder-brand-alt) / <alpha-value>)",
+            50: "rgb(var(--ryder-brand-alt-50) / <alpha-value>)",
+            100: "rgb(var(--ryder-brand-alt-100) / <alpha-value>)",
+            200: "rgb(var(--ryder-brand-alt-200) / <alpha-value>)",
+            300: "rgb(var(--ryder-brand-alt-300) / <alpha-value>)",
+            400: "rgb(var(--ryder-brand-alt-400) / <alpha-value>)",
+            500: "rgb(var(--ryder-brand-alt-500) / <alpha-value>)",
+            600: "rgb(var(--ryder-brand-alt-600) / <alpha-value>)",
+            700: "rgb(var(--ryder-brand-alt-700) / <alpha-value>)",
+            800: "rgb(var(--ryder-brand-alt-800) / <alpha-value>)",
+            900: "rgb(var(--ryder-brand-alt-900) / <alpha-value>)",
+            950: "rgb(var(--ryder-brand-alt-950) / <alpha-value>)",
+          },
+          accent: {
+            DEFAULT: "rgb(var(--ryder-accent) / <alpha-value>)",
+            50: "rgb(var(--ryder-accent-50) / <alpha-value>)",
+            100: "rgb(var(--ryder-accent-100) / <alpha-value>)",
+            200: "rgb(var(--ryder-accent-200) / <alpha-value>)",
+            300: "rgb(var(--ryder-accent-300) / <alpha-value>)",
+            400: "rgb(var(--ryder-accent-400) / <alpha-value>)",
+            500: "rgb(var(--ryder-accent-500) / <alpha-value>)",
+            600: "rgb(var(--ryder-accent-600) / <alpha-value>)",
+            700: "rgb(var(--ryder-accent-700) / <alpha-value>)",
+            800: "rgb(var(--ryder-accent-800) / <alpha-value>)",
+            900: "rgb(var(--ryder-accent-900) / <alpha-value>)",
+            950: "rgb(var(--ryder-accent-950) / <alpha-value>)",
+          },
+          "chrome-from": "rgb(var(--ryder-chrome-from) / <alpha-value>)",
+          "chrome-to": "rgb(var(--ryder-chrome-to) / <alpha-value>)",
+        },
+      },
       fontFamily: {
         // Resolves through --ryder-font-family so that `font-titillium` — the
         // class baseof.html puts on <body> by default — follows

--- a/tests/e2e/darkmode.spec.js
+++ b/tests/e2e/darkmode.spec.js
@@ -2,6 +2,50 @@ import { test, expect } from '@playwright/test'
 
 const BASE = '/ryder'
 
+// The one exampleSite page that renders both aside blocks: tag chips and the TOC.
+const ASIDE_PAGE = `${BASE}/docs/table-of-contents/`
+
+// The value `property` is declared with in the stylesheet rule for `selector`,
+// normalized through a throwaway element so it compares equal to what
+// getComputedStyle returns. Returns null when no such rule declares it, which
+// is itself a failure worth catching. Reading the palette out of the stylesheet
+// instead of hardcoding rose-950 keeps these assertions about the cascade —
+// does the `dark:` rule win? — and not about which colour the theme picked.
+async function declaredValue(page, selector, property) {
+  return page.evaluate(
+    ([selector, property]) => {
+      for (const sheet of document.styleSheets) {
+        let rules
+        try {
+          rules = sheet.cssRules
+        } catch {
+          continue // cross-origin (the Google Fonts sheet)
+        }
+        for (const rule of rules) {
+          if (rule.selectorText !== selector) continue
+          const declared = rule.style.getPropertyValue(property)
+          if (!declared) continue
+          const probe = document.createElement('div')
+          probe.style.setProperty(property, declared)
+          document.body.append(probe)
+          const normalized = getComputedStyle(probe).getPropertyValue(property)
+          probe.remove()
+          return normalized
+        }
+      }
+      return null
+    },
+    [selector, property]
+  )
+}
+
+async function switchToDark(page) {
+  // The switcher cycles system -> light -> dark, so light comes first.
+  await page.getByRole('button', { name: /light theme/i }).click()
+  await page.getByRole('button', { name: /dark theme/i }).click()
+  await expect(page.locator('html')).toHaveClass(/dark/)
+}
+
 test('dark mode toggle buttons are present on the page', async ({ page }) => {
   await page.goto(`${BASE}/docs/`)
   const themeSwitcher = page.locator('#themeSwitcher')
@@ -37,6 +81,52 @@ test('dark mode preference persists across page reload', async ({ page }) => {
 
   await page.reload()
   await expect(page.locator('html')).toHaveClass(/dark/)
+})
+
+// `.aside-taxonomy-link` and `.aside-toc-links a` build their dark styles from
+// `@apply dark:*` split across several statements inside `@layer components`.
+// Tailwind emits those as a separate `:is(.dark *)` rule that has to out-weigh
+// the base rule on specificity alone. These lock that in. They also ride out
+// the chips' 150ms `transition-colors`: toHaveCSS retries, so it settles on the
+// end value rather than sampling the transition's light starting value.
+test('aside tag chips take their dark styles in dark mode', async ({ page }) => {
+  await page.goto(ASIDE_PAGE)
+  const chip = page.locator('.aside-taxonomy-link').first()
+  await expect(chip).toBeVisible()
+
+  const properties = ['background-color', 'border-color', 'color']
+  const light = {}
+  for (const property of properties) {
+    light[property] = await declaredValue(page, '.aside-taxonomy-link', property)
+    expect(light[property], `.aside-taxonomy-link declares no ${property}`).toBeTruthy()
+  }
+
+  await switchToDark(page)
+
+  for (const property of properties) {
+    const dark = await declaredValue(page, '.aside-taxonomy-link:is(.dark *)', property)
+    expect(dark, `no dark rule declares ${property}`).toBeTruthy()
+    expect(dark, `the dark ${property} is the light one`).not.toBe(light[property])
+    await expect(chip).toHaveCSS(property, dark)
+  }
+})
+
+test('aside TOC links take their dark hover background', async ({ page }) => {
+  await page.goto(ASIDE_PAGE)
+  const link = page.locator('.aside-toc-links a').first()
+  await expect(link).toBeVisible()
+
+  await switchToDark(page)
+
+  const hoverBackground = await declaredValue(
+    page,
+    '.aside-toc-links a:hover:is(.dark *)',
+    'background-color'
+  )
+  expect(hoverBackground, 'no dark hover rule declares background-color').toBeTruthy()
+
+  await link.hover()
+  await expect(link).toHaveCSS('background-color', hoverBackground)
 })
 
 test('dismissable alert can be closed', async ({ page }) => {

--- a/theme.toml
+++ b/theme.toml
@@ -1,5 +1,5 @@
 name = 'ryder'
-version = 'v0.3.1'
+version = 'v0.4.0'
 license = 'MIT'
 licenselink = 'https://github.com/arts-link/ryder/LICENSE'
 description = 'A fast, accessible Hugo theme built with TailwindCSS and Alpine.js. Ships with dark mode, responsive navigation with dropdowns, OpenGraph image generation, Leaflet maps, photo galleries, recipe schema, share buttons, customizable headers and footers, and a Content Security Policy meta tag. Built for blogs, portfolios, and small business sites. Easily extended without modifying theme files.'


### PR DESCRIPTION
First of two PRs from the design-system handoff. **PR 2 (the `/docs/design-system/` page) depends on this one** — it renders the components added here.

## What this does

**Token layer.** `tailwind.preset.js` gains a `ryder` color namespace whose values resolve through CSS custom properties, defaulted in a new `:root` block in `assets/css/main.css`. Values are space-separated RGB channels rather than hex so `<alpha-value>` can interpolate — a hex inside `var()` works for `text-`/`bg-`/`border-` and then silently breaks every opacity modifier, which the theme leans on throughout.

Each of `brand` / `brand-alt` / `accent` carries a full 50–950 ramp, because the theme's classes span most of it (the nav alone runs `brand-100` to `brand-800`). The ramp step matching a family's canonical shade points back at the headline token (`--ryder-brand-800: var(--ryder-brand)`), so setting one token retints both it and its keyed step.

Sites override via `[params.colors]`, read by the new `head/colors.html` following the `--ryder-font-family` precedent. It is called *after* `head/css.html` so the override's `:root` wins, validates channel triplets, and warns on unknown keys rather than half-applying them.

**Accent consolidation — the only visual change.** The tag cloud's yellow border/hover/ring and the default CTA's fuchsia border/hover/ring both move to the accent, taking the theme from six accent families to one. The tag cloud's lime gradient stays: it reads as brand, and it is the chip's fill rather than its accent. `params.colors.legacyAccents = true` restores both.

**Three new components.** `utils/form-field.html` (the visual layer for the existing `ryderForm` engine), a `table-wrapper` shortcode (prose tables can't be restyled from inside `@tailwindcss/typography`, so the shell opts out with `not-prose` and scrolls horizontally), and `utils/empty-state.html` wired into `list.html`, which previously rendered a blank page with a dead pager.

## Verification

- `npm test` — 14 passed
- `npx playwright test` — 69 passed, `navClass.spec.js` untouched
- Clean cold and warm exampleSite builds, zero warnings
- `legacyAccents` toggled both ways; `[params.colors]` override chain confirmed live in the browser

**The migration is provably pixel-identical.** Built `a124253e6472` and this branch, resolved the token indirection back to literals, and diffed the compiled stylesheets: zero selectors lost, and exactly one declaration changed in notation only (`#0ea5e9` → `rgb(14 165 233 / 1)`, same sky-500).

## Review points — where this deviates from the handoff

1. **Kebab class names.** The handoff specified `brandAlt`/`chromeFrom`. This uses `ryder-brand-alt` / `ryder-chrome-from` so the config key, CSS variable, and Tailwind class are spelled identically. **The design reference is stale on this point.**
2. **The handoff's icon instruction was wrong.** It said add `fa-signs-post`/`fa-circle-check` to `extended.js` and the test. Both are already in `library.add()` in `assets/js/main.js`, and `extended.js` is the *user's* hook, not where theme icons go. No change needed.
3. **Empty-state precedent.** The handoff pointed at `hideIfEmptyData`, which hides a *menu entry*. The closer precedent is `dataSource`/`emptyDataMessage` in `list-plain.html`, documented as exactly this counterpart. Modeled on that instead.
4. **Header edge uses a literal `border-rose-500`, not `border-ryder-accent-500`.** Handoff 1b says the edge moves to accent; `docs/design-decisions.md` §3 says shipped config strings stay literal. Literal-but-rose satisfies both and keeps a copied config from depending on the token layer. §3's fuchsia example is stale as written.
5. **CTA class string regrouped** (accent classes together). Same classes, same rendering — attribute order doesn't affect the cascade. Also removed the duplicate copy the `cta-button` shortcode carried, via the new `utils/cta-class.html`.
6. **`forms.md` and `analytics/index.md` still show fuchsia** in their hand-written `class=` examples, per the "don't change class strings quoted in docs" rule. They're PR 2's territory, but will read oddly next to a rose default until then.

## Dark-mode coverage (second commit)

An earlier draft of this description claimed the aside tag chips failed to take their dark-mode background. **That was wrong** — it was a measurement error: `.aside-taxonomy-link` carries `transition-colors duration-150`, and reading `getComputedStyle` in the same tick as the `.dark` class toggle samples the transition at t=0. The `:is(.dark *)` rule out-weighs the base rule on specificity and applies correctly.

`8472c3a` adds e2e coverage for it, since nothing asserted that cascade held: the chips' dark background, border, and text colour, plus the TOC links' dark hover background. Expected values are read out of the stylesheet rule rather than hardcoded, so the assertions test the cascade rather than which colour the palette currently names — and they resolve the accent-token indirection this branch introduces.

## Outstanding for the 0.4.0 tag

`images/screenshot.png` (1500x1000) and `images/tn.png` (900x600) need refreshing per CLAUDE.md. Deferred until after PR 2, so they reflect the complete release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

