### PR TITLE
v0.4.0 (PR 2): the design-system page, rendered by the live theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ Named after a late Rhodesian Ridgeback/Mastiff companion.
 
 ## What's New in v0.4.0
 
-- **Semantic color tokens** — the palette resolves through `--ryder-*` custom properties, so `[params.colors]` can repoint brand, brand-alt, accent, and the header/footer chrome without overriding a single class string. See [Color Tokens](#color-tokens).
+- **Semantic color tokens** — the palette resolves through `--ryder-*` custom properties, so `[params.colors]` can repoint brand, brand-alt, and accent without overriding a single class string. See [Color Tokens](#color-tokens).
 - **One accent instead of six** — the tag cloud's yellow border and the CTA button's fuchsia ring both move to the theme accent (rose). `params.colors.legacyAccents = true` restores them.
 - **Three new components** — a themed [form field](#form-fields) partial for the existing `ryderForm` engine, a `table-wrapper` shortcode that keeps wide tables from pushing the page sideways, and an empty state on list pages that no longer renders a blank page with a dead pager.
+- **A design-system page** — [arts-link.github.io/ryder/docs/design-system/](https://arts-link.github.io/ryder/docs/design-system/) documents the tokens, type scale, spacing, and every component, rendered by the live theme rather than screenshots of it.
 
 Sites upgrading from v0.3.x should read the [v0.4.0 migration guide](docs/migration/v0.4.0.md) — the accent change is the only thing that alters an existing site, and it is one config flag to undo. The reasoning behind the system is recorded in [docs/design-decisions.md](docs/design-decisions.md).
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -34,6 +34,7 @@ import {
   faSignsPost,
   faSnowflake,
   faSun,
+  faSwatchbook,
   faTags,
   faTimes,
   faTriangleExclamation,
@@ -64,7 +65,7 @@ library.add(
   faCircleInfo, faCode, faComputer, faDumpsterFire, faDungeon, faGlobe,
   faHouse, faImage, faMapLocationDot, faMoon, faMusic, faOm,
   faPenToSquare,
-  faShieldDog, faSignsPost, faSnowflake, faSun, faTags, faTimes,
+  faShieldDog, faSignsPost, faSnowflake, faSun, faSwatchbook, faTags, faTimes,
   faRss, faSeedling, faTriangleExclamation, faUtensils, faWandMagicSparkles, faXmark,
   // regular
   farEnvelope, farHandPointLeft, farHandPointRight,

--- a/exampleSite/content/docs/design-system.md
+++ b/exampleSite/content/docs/design-system.md
@@ -1,0 +1,399 @@
++++
+title = 'Design System'
+date = 2026-08-04T09:00:00-07:00
+description = 'Ryder’s colour tokens, type scale, spacing, and components — documented by the live theme rather than a screenshot of it.'
+homeFeature = true
+homeFeatureTitle = "Design System"
+homeFeatureIcon = "fa-solid fa-swatchbook"
+categories = ["home-page"]
+tags = ["design", "tailwind", "tokens", "theming", "components"]
+showToc = true
+[menu]
+ [menu.main]
+  weight = 5
+  parent = 'docs'
++++
+
+Every preview on this page is the real component, rendered by the same partial
+your site calls. Nothing here is a mockup, so nothing here can drift.
+
+<!--more-->
+
+That is the whole point of documenting a theme from inside itself. A
+hand-maintained page of static markup is wrong the first time someone edits a
+partial, and wrong *invisibly*. This page inherits the real dark mode, the real
+table of contents, and the real aside — because it is a normal page of the
+site it documents.
+
+Values quoted below come from `data/design-system.json`, so each one exists in
+exactly one place. The reasoning behind the system — why rose is the accent,
+why tokens are channels rather than hex — lives in
+[`docs/design-decisions.md`](https://github.com/arts-link/ryder/blob/main/docs/design-decisions.md)
+in the repository, because it is maintainer-facing and does not belong in a
+site build.
+
+---
+
+# Foundations
+
+## Overview
+
+Three commitments shape everything else.
+
+**Tailwind, barely extended.** `tailwind.preset.js` adds a colour token
+namespace, two breakpoints (`xs`, `3xl`), a font family that resolves through a
+custom property, and four background images. That is all. Ryder does not ship a
+parallel design language on top of Tailwind — if you know Tailwind, you know
+this theme.
+
+**Config is the API.** Colours, header and footer classes, body classes, fonts,
+menus, and card gradients are all reachable from `hugo.toml`. Overriding a
+template should be a last resort, not the first step.
+
+**CSP-safe by default.** The theme ships a Content Security Policy with no
+`'unsafe-inline'` for scripts, and uses the CSP build of Alpine. That
+constrains component design in ways worth knowing about — see
+[Dark mode](#dark-mode) and [Form field](#form-field).
+
+## Color
+
+Four semantic roles. Each resolves through a CSS custom property, so a site can
+repoint the palette without touching a class string.
+
+{{< swatch name="brand" >}}
+{{< swatch name="brand-alt" >}}
+{{< swatch name="accent" >}}
+
+The chips above are painted from the live custom properties. Override
+`[params.colors]` and they move with the rest of the theme.
+
+{{< token-table group="color" >}}
+
+`chrome-from` and `chrome-to` are the exception worth stating plainly: they are
+declared and usable in your own class strings, but **nothing in the theme reads
+them.** The header and footer gradients arrive through
+`twClasses.headerBackgroundFrameOuter`, which deliberately stays a literal
+Tailwind string. Setting them will not retint your header.
+
+### What is deliberately not tokenized
+
+{{< token-table group="untokenized" >}}
+
+The alert colours are the sharpest case. Yellow in an alert means *warning* —
+that survives a rebrand, and routing it through a brand token would destroy it.
+
+### Card category gradients
+
+Cards colour their header band from `cardCategoryColorsDefault`, set per
+category or per page rather than from a token, because the point is that
+categories differ from one another:
+
+```toml
+# content/categories/recipes/_index.md
+cardCategoryColorsDefault = "bg-gradient-to-r from-amber-500 to-orange-500 text-neutral-900"
+```
+
+## Typography
+
+Titillium Web 400/600/700, loaded by `head/fonts.html` and resolved through
+`--ryder-font-family` so `[params.fonts] family` can repoint it without a fork.
+
+{{< token-table group="type" >}}
+
+Note there are three eyebrow treatments, not one — `0.18em` in aside headings,
+`0.2em` on article meta and form labels, `0.22em` on the share and footer
+rails. They are close enough to look like a mistake and far enough apart to be
+deliberate; if you are adding a label, match the neighbourhood it sits in.
+
+## Space, radius, shadow
+
+{{< token-table group="radius" >}}
+
+{{< token-table group="shadow" >}}
+
+Elevation carries one interaction: a card lifts from `shadow-sm` to `shadow-md`
+on hover over 200ms. Nothing else in the theme animates elevation.
+
+{{< token-table group="container" >}}
+
+## Icons
+
+Font Awesome, **tree-shaken**. Only icons explicitly imported into
+`assets/js/main.js` ship in the bundle — an icon class used in a template but
+never imported renders Font Awesome's placeholder glyph instead.
+
+Adding one is three steps:
+
+```js
+// 1. find the camelCase name:  fa-swatchbook → faSwatchbook
+// 2. import it (keep the list alphabetical)
+import { faSwatchbook } from '@fortawesome/free-solid-svg-icons'
+// 3. add it to library.add(...)
+```
+
+`tests/unit/faIcons.test.js` enforces this in both directions: an icon used but
+not imported fails, and an icon imported but never used fails too. The icon in
+this page's title had to be added to `main.js` before this page would pass.
+
+Your own icons go in `assets/js/extended.js` — the user hook — not in
+`main.js`.
+
+## Dark mode
+
+Three modes, set with `params.darkMode`:
+
+| Value | Behaviour |
+|---|---|
+| `system` | Follows the OS preference. The default. |
+| `toggle` | Adds the footer control, and remembers the choice |
+| `off` | No dark mode at all — every `dark:` class is omitted from `<body>` |
+
+`off` is a real omission, not a CSS override, which is why `twClasses.body` and
+`twClasses.bodyDark` are separate params: changing your body font cannot
+silently re-enable or disable dark mode.
+
+The toggle you see in the footer of this page is the live component. Try it —
+the swatches, tables, and form below all follow.
+
+### Pairing rules
+
+Surfaces pair `neutral-100` with `neutral-900`, panels pair white with
+`slate-900/70`, and borders pair `slate-200/80` with `slate-700/70`. Colour
+tokens shift *step*, not hue: article meta icons are `brand-700` in light and
+`brand-300` in dark.
+
+## Tokens
+
+The token layer is the preferred way to restyle Ryder's colour. Full reference
+in [CSS Overrides](/docs/css-overrides/#color-tokens); the shape of it:
+
+```toml
+[params.colors]
+  brand     = "12 74 110"    # channels, not hex
+  accent    = "217 70 239"
+  accent-600 = "192 38 211"  # set every step a component uses
+```
+
+Two things that catch people out, both worth stating twice:
+
+1. **Channels, not hex.** `"244 63 94"`, never `"#f43f5e"`. A hex inside
+   `var()` works for `text-`/`bg-`/`border-` and then silently produces nothing
+   for every opacity modifier — with no build error. A malformed value here is
+   ignored with a build warning naming the key.
+2. **The bare token moves one ramp step**, and which step differs per family:
+   `brand`→`brand-800`, `brand-alt`→`brand-alt-800`, `accent`→`accent-500`.
+   Setting `accent` alone leaves the CTA's `accent-600` border and `accent-300`
+   ring at their defaults.
+
+---
+
+# Components
+
+## Header, logo, nav
+
+**The header above this page is the component.** Its outer frame, inner frame,
+background image, and nav skin are all config:
+
+```toml
+[params.twClasses]
+  headerBackgroundFrameOuter = "bg-gradient-to-r from-slate-900 to-slate-700 border-b border-rose-500 text-neutral-100"
+  headerBackgroundFrameInner = "h-[240px] sm:h-[400px] bg-cover bg-center sm:bg-[center_30%]"
+  headerBackgroundImage = "images/hyder_theme_header.webp"
+```
+
+The logo splits `logo_firstWord` and `logo_lastWord` across `ryder-brand-800`
+and `ryder-brand-alt-800` — the brand pair, and the reason sky and lime are
+brand rather than incidental. The nav encodes the same pair: links are
+`brand-800`, the active entry is `brand-alt-800`.
+
+Classes: `max-w-screen-xl px-3 py-3 md:px-4` on the shell, `rounded-lg` on the
+inner frame, `rounded-full` on the mobile hamburger.
+
+## Cards
+
+**The card grid on the [home page](/) and every list page is the component.**
+Variants are selected by config rather than by forking a template:
+
+```toml
+[params]
+  listCardType = "-category-color"   # layouts/partials/card-category-color.html
+```
+
+A card is `rounded-xl` with `shadow-sm`, lifting to `shadow-md` on hover over
+200ms. The header band takes its gradient from the page's category. Grid gutter
+is `gap-6`.
+
+## Article header & aside
+
+**This page is the component.** The header band above, with its icon, title,
+and meta row, is `.article-header-*`; the aside to the side of this text holds
+the tag chips and the table of contents.
+
+Aside internals are the accent's home ground — `.aside-taxonomy-icon` and
+`.aside-toc-icon` are `ryder-accent-500`, and the tag chips are the accent's
+`50`/`300`/`400`/`100` steps in light and `950`/`900`/`700` in dark. That is
+why rose won the accent slot: it was already structural here.
+
+```go-html-template
+{{ partial "terms.html" (dict "taxonomy" "tags" "page" .) }}
+{{ partial "toc.html" . }}
+```
+
+## Breadcrumb, pagination, taxonomy
+
+The breadcrumb above this article and the pager on any list page are live.
+The tag cloud is embeddable, so here it is:
+
+{{< taxonomy-cloud >}}
+
+Chips are `rounded-full` with a lime gradient fill and an accent
+border/hover/ring. The fill is brand; only the edge is accent. Through v0.3.x
+that edge was yellow — a sixth accent family with no other use in the theme.
+
+## Alerts
+
+Four semantic types. These are live `alert-wrapper` calls:
+
+{{< alert-wrapper alertType="info" alertTitle="Info" alertMessage="Blue. Neutral information the reader did not ask for." >}}
+
+{{< alert-wrapper alertType="success" alertTitle="Success" alertMessage="Green. Something worked." >}}
+
+{{< alert-wrapper alertType="warning" alertTitle="Warning" alertMessage="Yellow — and this yellow is semantic, which is why it is not routed through a colour token." >}}
+
+{{< alert-wrapper alertType="danger" alertTitle="Danger" alertMessage="Red. Something is broken or about to be." dismissable=true >}}
+
+```
+{{</* alert-wrapper alertType="warning" alertTitle="Heads up"
+     alertMessage="Body text." dismissable=true */>}}
+```
+
+Each type is a `50`/`300`/`800` triple of its hue. `dismissable=true` adds an
+Alpine-backed close button. The same partial powers site-wide banners via
+`[[params.alphaAlert]]`.
+
+## Buttons & CTAs
+
+Live `cta-button` shortcodes:
+
+{{< cta-button button_label="Default CTA" button_href="#buttons--ctas" >}}
+
+{{< cta-button button_label="Amazon variant" button_type="amazon" button_href="#buttons--ctas" >}}
+
+{{< cta-button button_label="Spotify variant" button_type="spotify" button_href="#buttons--ctas" >}}
+
+```
+{{</* cta-button button_label="Read the docs" button_relref="/docs" */>}}
+```
+
+The default is `rounded-full` on `bg-slate-800` with an accent border, hover
+border, and focus ring — `accent-600`/`500`/`300`. The Amazon and Spotify
+variants use those platforms' own colours on purpose, and should never be
+borrowed for a generic button.
+
+`params.colors.legacyAccents = true` restores the pre-v0.4.0 fuchsia edge.
+
+## Share buttons
+
+Live at the foot of this article when `showShareButtons` is on. Each network
+button is `rounded-lg` with the platform's brand colour at `88%` opacity,
+deepening to `92%` on hover — one of the places the channel-based tokens earn
+their keep, since a hex would break those modifiers.
+
+```toml
+[params.shareButtons]
+  networks = ["x", "email", "reddit", "facebook"]
+  size = "small"   # small | medium | large
+```
+
+## Footer
+
+**The footer below is the component.** It carries the menu, social icons from
+`data/social.json`, the dark-mode toggle, optional taxonomy clouds, and the
+meta rail. Its background falls back to `headerBackgroundFrameOuter` unless
+`twClasses.footerBackground` is set.
+
+---
+
+# Patterns
+
+## Shortcodes
+
+Content-level building blocks. Media: `picture`, `photo-gallery`,
+`video-lightbox`. Embeds: `youtube-embed`, `spotify-embed`, `soundcloud` — each
+registers its own CSP host. Maps: `leaflet`, `openstreetmap`, `lat-long-box`.
+Structured content: `recipe-ingredients-list`, `recipe-howto-steps-list`,
+`highlight-github`, `amazon-associate-link`.
+
+Full list in the [README](https://github.com/arts-link/ryder#shortcodes).
+
+## Form field
+
+*New in v0.4.0.* The form **engine** — `ryderForm` — already existed: it
+serializes fields to JSON, POSTs them, exposes request state, and swallows a
+`_gotcha` honeypot. What was missing was the visual layer, so sites shipped
+unstyled inputs next to styled buttons.
+
+This form is live. Submitting it lands in the error state on purpose, because
+the demo site has no backend:
+
+{{< form-demo >}}
+
+```go-html-template
+{{ partial "utils/form-field.html" (dict
+    "name" "email" "type" "email" "label" "Email"
+    "placeholder" "you@example.com" "required" true) }}
+```
+
+Field: `border border-slate-200/80 rounded-lg px-3 py-2.5 text-base
+bg-neutral-100 dark:bg-neutral-800`, focus ring `outline-2 outline-offset-2
+outline-ryder-brand`. Label: the `0.2em` eyebrow. The submit button reuses the
+default CTA class, so it follows `legacyAccents` with every other CTA.
+
+The status bindings are plain property lookups (`isLoading`, `isSuccess`,
+`isError`) rather than comparisons, because the CSP build of Alpine cannot
+evaluate `status === 'success'`. Full engine docs in [Forms](/docs/forms/).
+
+## Table wrapper
+
+*New in v0.4.0.* `@tailwindcss/typography` owns table styling inside `prose`
+and it cannot be overridden from within — so the wrapper opts out with
+`not-prose` and re-states the cell styling. It also scrolls horizontally
+instead of pushing the page sideways on a phone.
+
+Every table on this page is one. Here is one being one:
+
+{{< table-wrapper >}}
+| Param | Default | Notes |
+|---|---|---|
+| `showDate` | `true` | Show post dates on cards and articles |
+| `showAuthor` | `true` | Show the author on single pages |
+| `showShareButtons` | `false` | Share row at the foot of an article |
+{{< /table-wrapper >}}
+
+```
+{{</* table-wrapper */>}}
+| Param | Default |
+|---|---|
+| `showDate` | `true` |
+{{</* /table-wrapper */>}}
+```
+
+Shell: `border border-slate-200/80 rounded-xl overflow-hidden`, header cells
+`bg-neutral-100 dark:bg-neutral-800 font-bold px-3.5 py-2.5`, rows separated by
+`border-b border-slate-200/50`.
+
+## Empty state
+
+*New in v0.4.0.* A paginated list with nothing in it used to render a blank
+grid followed by pagination controls for a single page of nothing.
+
+**[See it live on the Empty Section page →](/docs/empty-section/)**
+
+It is the third of three answers to "nothing here", and the only one needing no
+configuration — the other two are `hideIfEmptyData` on a menu entry, and
+`dataSource` + `emptyDataMessage` on a `list-plain` page. Wording comes from
+`i18n/` (`emptyListTitle`, `emptyListBody`), so it translates rather than
+configures.
+
+Shell: `border border-dashed rounded-xl p-9 text-center`, `fa-signs-post` in
+accent, `text-lg font-semibold` headline, muted body, and the default CTA home.

--- a/exampleSite/content/docs/empty-section/_index.md
+++ b/exampleSite/content/docs/empty-section/_index.md
@@ -1,0 +1,26 @@
++++
+title = "Empty Section"
+description = "A section with no pages in it — demonstrates the empty state that layouts/_default/list.html renders instead of a blank grid and a dead pager."
+homeFeatureIcon = "fa-solid fa-signs-post"
+[menu]
+ [menu.main]
+  parent = 'docs'
+  weight = 95
++++
+
+**This section is empty on purpose.** There are no pages under it, so the
+paginator yields nothing and `layouts/_default/list.html` renders its empty
+state below instead of an empty grid followed by pagination controls for a
+single page of nothing.
+
+It is the third of the theme's three answers to "nothing here", and the only
+one that needs no configuration:
+
+| Behaviour | Mechanism | When it fits |
+|---|---|---|
+| The menu entry disappears | `hideIfEmptyData` under the entry's `params` | A link with nothing behind it is a dead end — see [Releases](/docs/releases/) |
+| The page stays and explains itself | `dataSource` + `emptyDataMessage` on a `list-plain` page | A vanished entry looks like a removed feature — see [Showcase](/docs/showcase/) |
+| The list says so itself | *nothing — this page* | A real section that simply has no posts yet |
+
+The wording comes from `i18n/` (`emptyListTitle`, `emptyListBody`), so it is
+translated rather than configured. Override it there.

--- a/exampleSite/content/docs/forms.md
+++ b/exampleSite/content/docs/forms.md
@@ -76,6 +76,44 @@ Add `data-track-event` (and optionally `data-track-props`) to the `<form>` and i
 fires through the same provider path as [`ryderTrack`](../analytics/) once the
 POST succeeds — never on failure.
 
+## Styling the fields
+
+*New in v0.4.0.* Everything above is the **engine**. It has no opinion about
+what a field looks like, which is why the demo below hand-writes its classes.
+
+`utils/form-field.html` is the matching visual layer, so you no longer have to:
+
+```go-html-template
+<form x-data="ryderForm" @submit.prevent="submit"
+      data-form-action="https://api.example.com/subscribe">
+  {{ partial "utils/form-field.html" (dict
+      "name" "email" "type" "email" "label" "Email"
+      "placeholder" "you@example.com" "required" true) }}
+  {{ partial "utils/form-field.html" (dict
+      "name" "message" "type" "textarea" "label" "Message" "rows" 3) }}
+
+  <input type="text" name="_gotcha" tabindex="-1" autocomplete="off"
+         class="hidden" aria-hidden="true">
+
+  {{ partial "utils/form-field.html" (dict
+      "type" "submit" "label" "Subscribe" "successMessage" "Thanks!"
+      "errorMessage" "") }}
+</form>
+```
+
+It renders text-like inputs, `textarea`, and a `submit` variant that reuses the
+theme's default CTA class and binds `:disabled` to `isLoading`. Pass
+`successMessage` / `errorMessage` on the submit field to get the status lines
+too — an empty `errorMessage` defers to whatever the engine put in its own
+`errorMessage` property.
+
+The honeypot stays hand-written on purpose: it is one line, and a field partial
+that emitted an invisible input would be a partial that appears to render
+nothing.
+
+Full parameter list, and a live example, on the
+[Design System](/docs/design-system/#form-field) page.
+
 ## Content Security Policy
 
 `fetch` to another origin is blocked unless the action's host is in

--- a/exampleSite/data/design-system.json
+++ b/exampleSite/data/design-system.json
@@ -1,0 +1,102 @@
+{
+  "_comment": "Single source of truth for the values quoted on /docs/design-system/. Read by the swatch and token-table shortcodes. Every value here was read out of the theme (assets/css/main.css, tailwind.preset.js, layouts/partials/*) rather than transcribed from the design reference — where the two disagreed, the repo won.",
+
+  "_columns": {
+    "color": ["name", "token", "channels", "hex", "tailwind", "alias", "usage"],
+    "untokenized": ["name", "value", "why"],
+    "type": ["role", "size", "classes", "where"],
+    "radius": ["name", "value", "where"],
+    "shadow": ["name", "where"],
+    "container": ["name", "value", "where"]
+  },
+
+  "color": [
+    {
+      "name": "brand",
+      "token": "--ryder-brand",
+      "channels": "7 89 133",
+      "hex": "#075985",
+      "tailwind": "sky-800",
+      "alias": "ryder-brand-800",
+      "usage": "Logo word 1, nav links, article meta icons, blockquote rule"
+    },
+    {
+      "name": "brand-alt",
+      "token": "--ryder-brand-alt",
+      "channels": "63 98 18",
+      "hex": "#3f6212",
+      "tailwind": "lime-800",
+      "alias": "ryder-brand-alt-800",
+      "usage": "Logo word 2, active nav entry"
+    },
+    {
+      "name": "accent",
+      "token": "--ryder-accent",
+      "channels": "244 63 94",
+      "hex": "#f43f5e",
+      "tailwind": "rose-500",
+      "alias": "ryder-accent-500",
+      "usage": "Aside icons, tag chips, tag cloud, CTA hover"
+    },
+    {
+      "name": "chrome-from",
+      "token": "--ryder-chrome-from",
+      "channels": "15 23 42",
+      "hex": "#0f172a",
+      "tailwind": "slate-900",
+      "alias": "",
+      "usage": "Declared only — nothing in the theme reads it"
+    },
+    {
+      "name": "chrome-to",
+      "token": "--ryder-chrome-to",
+      "channels": "51 65 85",
+      "hex": "#334155",
+      "tailwind": "slate-700",
+      "alias": "",
+      "usage": "Declared only — nothing in the theme reads it"
+    }
+  ],
+
+  "untokenized": [
+    { "name": "Surfaces", "value": "neutral-100/200/300/700/800/900", "why": "Page and panel backgrounds. Repointing these is choosing a different theme, not configuring this one." },
+    { "name": "Structural greys", "value": "slate-500, slate-200/80, slate-700/70", "why": "Meta labels and card borders. Neutral scaffolding, not brand." },
+    { "name": "Alert hues", "value": "blue / green / yellow / red at 50-300-800", "why": "Semantic. Yellow means warning; routing it through a brand token would destroy the meaning." },
+    { "name": "Platform fills", "value": "Amazon yellow, Spotify green", "why": "They match the platforms they link to. Not Ryder's colours to change." }
+  ],
+
+  "type": [
+    { "role": "Logo", "classes": "text-4xl font-bold", "size": "36px / 700", "where": "logo.html" },
+    { "role": "Tagline", "classes": "text-xs font-bold tracking-[0.4em]", "size": "12px / 700", "where": "logo.html" },
+    { "role": "h1", "classes": "text-2xl font-bold tracking-tight", "size": "24px / 700", "where": "@layer base" },
+    { "role": "h2", "classes": "text-xl font-semibold tracking-tight", "size": "20px / 600", "where": "@layer base" },
+    { "role": "h3", "classes": "text-lg font-bold my-2", "size": "18px / 700", "where": "@layer base" },
+    { "role": "h4", "classes": "text-base font-bold my-1", "size": "16px / 700", "where": "@layer base" },
+    { "role": "Body", "classes": "prose lg:prose-lg dark:prose-invert", "size": "typography plugin", "where": ".articleBody" },
+    { "role": "Eyebrow (aside)", "classes": "text-xs font-semibold uppercase tracking-[0.18em]", "size": "12px / 600", "where": ".aside-*-heading" },
+    { "role": "Eyebrow (meta)", "classes": "text-[11px] font-semibold uppercase tracking-[0.2em]", "size": "11px / 600", "where": ".article-header-meta-label, form-field label" },
+    { "role": "Eyebrow (rail)", "classes": "text-[11px] font-semibold uppercase tracking-[0.22em]", "size": "11px / 600", "where": ".share-module-label, .footer-utility-label" }
+  ],
+
+  "radius": [
+    { "name": "rounded-md", "value": "6px", "where": "Nav links, TOC links, footer submenu" },
+    { "name": "rounded-lg", "value": "8px", "where": "Header inner frame, alerts, nav list, share buttons, form fields" },
+    { "name": "rounded-xl", "value": "12px", "where": "Cards, article header shell, aside panels, table wrapper, empty state" },
+    { "name": "rounded-full", "value": "9999px", "where": "CTAs, tag cloud chips, social icons, hamburger, theme toggle" }
+  ],
+
+  "shadow": [
+    { "name": "shadow-sm", "where": "Card at rest, article header shell, aside panels, share buttons" },
+    { "name": "shadow-md", "where": "Card on hover — transition-shadow duration-200 ease-in-out" },
+    { "name": "shadow-lg", "where": "Open nav submenu" }
+  ],
+
+  "container": [
+    { "name": "max-w-screen-xl", "value": "1280px", "where": "Header and footer shells" },
+    { "name": "max-w-screen-lg", "value": "1024px", "where": "List and single page content" },
+    { "name": "px-3 md:px-4", "value": "12px → 16px", "where": "Header and footer gutters" },
+    { "name": "gap-6", "value": "24px", "where": "Card grid" },
+    { "name": "xs", "value": "475px", "where": "Preset addition, below Tailwind's sm" },
+    { "name": "3xl", "value": "1600px", "where": "Preset addition, above Tailwind's 2xl" }
+  ]
+}

--- a/exampleSite/layouts/shortcodes/form-demo.html
+++ b/exampleSite/layouts/shortcodes/form-demo.html
@@ -1,0 +1,32 @@
+{{- /*
+A complete, live `ryderForm` built out of the theme's own
+utils/form-field.html partial — the working preview for
+/docs/design-system/#form-field.
+
+This is an exampleSite shortcode, not a theme one. form-field is a *partial*,
+and a partial cannot be called from Markdown; wrapping the whole form here is
+what lets the docs page show the real component rather than a screenshot or a
+hand-copied block of HTML. It stays a demo: the action points at a path that
+does not exist, so submitting lands in the error state on purpose, exactly as
+/docs/forms/ does.
+
+The honeypot stays hand-written. It is one line, and a field partial that
+emitted an invisible input would be a partial that looks like it renders
+nothing.
+*/ -}}
+<form x-data="ryderForm" @submit.prevent="submit"
+      data-form-action="/ryder/api/design-system-demo"
+      data-error-message="No backend on the demo site — this is the error state."
+      class="not-prose my-4 flex max-w-md flex-col gap-4">
+  {{ partial "utils/form-field.html" (dict
+      "name" "email" "type" "email" "label" "Email"
+      "placeholder" "you@example.com" "required" true) }}
+  {{ partial "utils/form-field.html" (dict
+      "name" "message" "type" "textarea" "label" "Message" "rows" 3
+      "help" "Optional — the field partial renders help text when you pass it.") }}
+  <input type="text" name="_gotcha" tabindex="-1" autocomplete="off"
+         class="hidden" aria-hidden="true">
+  {{ partial "utils/form-field.html" (dict
+      "type" "submit" "label" "Subscribe"
+      "successMessage" "Thanks!" "errorMessage" "") }}
+</form>

--- a/exampleSite/layouts/shortcodes/swatch.html
+++ b/exampleSite/layouts/shortcodes/swatch.html
@@ -1,0 +1,50 @@
+{{- /*
+A single colour swatch for /docs/design-system/, read from
+data/design-system.json so a value lives in exactly one place.
+
+The chip is painted with an inline `rgb(var(--ryder-*))` rather than a
+`bg-ryder-*` class on purpose, and for two reasons:
+
+  1. It stays live. Override the token from [params.colors] and the swatch
+     moves with the rest of the theme, because it reads the same custom
+     property everything else does.
+  2. A class assembled from data would exist only in hugo_stats.json, which is
+     gitignored — so a cold clone's first build would emit CSS without it. See
+     CLAUDE.md > Release Maintenance for the three classes already in that
+     trap; this does not add a fourth.
+
+Inline styles are permitted by the theme's CSP (style-src carries
+'unsafe-inline' — see head/csp.html).
+
+@param name  Key from data.design-system.color. Required.
+
+@example {{< swatch name="accent" >}}
+*/ -}}
+{{- /* `index`, not dot access: the file name contains a hyphen, which a Go
+       template would parse as subtraction in `site.Data.design-system`. */ -}}
+{{- $name := .Get "name" -}}
+{{- $row := "" -}}
+{{- range index site.Data "design-system" "color" -}}
+  {{- if eq .name $name }}{{ $row = . }}{{ end -}}
+{{- end -}}
+{{- with $row -}}
+<div class="not-prose my-3 flex items-center gap-4 rounded-xl border border-slate-200/80 p-3 dark:border-slate-700/70">
+  {{- /* safeCSS: Go's html/template treats an interpolated value inside a
+         style attribute as untrusted CSS and replaces it with ZgotmplZ, which
+         silently paints nothing. The value is a custom-property name from this
+         repo's own data file. Same treatment head/fonts.html gives
+         --ryder-font-family. */ -}}
+  <div class="ryder-swatch-chip h-14 w-14 shrink-0 rounded-lg border border-black/10 dark:border-white/15"
+       data-token="{{ .token }}"
+       style="{{ printf "background-color: rgb(var(%s));" .token | safeCSS }}"></div>
+  <div class="min-w-0">
+    <p class="m-0 text-base font-bold">{{ .name }}</p>
+    <p class="m-0 text-sm text-slate-500 dark:text-slate-400">
+      <code>{{ .token }}</code> · <code>{{ .channels }}</code> · {{ .hex }} · {{ .tailwind }}
+    </p>
+    <p class="m-0 mt-1 text-sm">{{ .usage }}</p>
+  </div>
+</div>
+{{- else -}}
+  {{- errorf "swatch: no colour named %q in data/design-system.json" $name -}}
+{{- end -}}

--- a/exampleSite/layouts/shortcodes/token-table.html
+++ b/exampleSite/layouts/shortcodes/token-table.html
@@ -1,0 +1,46 @@
+{{- /*
+Renders one group from data/design-system.json as a table, wrapped in the
+theme's own table-wrapper styling so the page eats its own cooking.
+
+Column order comes from `_columns` in the data file rather than from the rows
+themselves: Go templates range over a map in sorted key order, so deriving
+headers from a row would alphabetise them and put `name` in the middle.
+
+`index`, not dot access: the data file name contains a hyphen, which a Go
+template would parse as subtraction in `site.Data.design-system`.
+
+@param group  Top-level key in data/design-system.json — color, untokenized,
+              type, radius, shadow, or container. Required.
+
+@example {{< token-table group="radius" >}}
+*/ -}}
+{{- $group := .Get "group" -}}
+{{- $rows := index site.Data "design-system" $group -}}
+{{- if not $rows -}}
+  {{- errorf "token-table: no group %q in data/design-system.json" $group -}}
+{{- else -}}
+{{- $cols := index site.Data "design-system" "_columns" $group -}}
+{{- if not $cols -}}
+  {{- errorf "token-table: group %q has no _columns entry in data/design-system.json" $group -}}
+{{- end -}}
+<div class="ryder-table not-prose my-4">
+  <div class="ryder-table-scroll">
+    <table>
+      <thead>
+        <tr>{{ range $cols }}<th>{{ humanize . }}</th>{{ end }}</tr>
+      </thead>
+      <tbody>
+        {{- range $rows }}
+        {{- $row := . }}
+        <tr>
+          {{- range $cols }}
+          {{- $cell := index $row . }}
+          <td>{{ if $cell }}{{ $cell }}{{ else }}<span class="opacity-50">—</span>{{ end }}</td>
+          {{- end }}
+        </tr>
+        {{- end }}
+      </tbody>
+    </table>
+  </div>
+</div>
+{{- end -}}

--- a/tests/e2e/designSystem.spec.js
+++ b/tests/e2e/designSystem.spec.js
@@ -1,0 +1,81 @@
+import { test, expect } from '@playwright/test'
+
+const BASE = '/ryder'
+const PAGE = `${BASE}/docs/design-system/`
+
+// The design-system page documents the theme by *rendering* it: every preview is
+// a live partial or shortcode call, which is the whole reason the page exists
+// rather than a hand-maintained one. That property is invisible in a screenshot
+// — a stale hardcoded copy of the markup would look identical — so it is what
+// these assertions check. If a preview here stops being live, the page has
+// quietly become the thing it was built to replace.
+
+test('swatches paint from the live colour tokens, not baked-in hex', async ({ page }) => {
+  await page.goto(PAGE)
+
+  // Selected by class, not by its style attribute: the override below puts
+  // --ryder-accent on <html>, which would otherwise match an attribute selector
+  // and re-resolve the locator to the document element mid-test.
+  //
+  // The chip reads rgb(var(--ryder-accent)). Overriding the custom property has
+  // to move it; a swatch painted with a literal #f43f5e would not budge, and
+  // that is exactly the drift this page is supposed to be immune to.
+  const chip = page.locator('.ryder-swatch-chip[data-token="--ryder-accent"]')
+  await expect(chip).toHaveCSS('background-color', 'rgb(244, 63, 94)')
+
+  await page.evaluate(() =>
+    document.documentElement.style.setProperty('--ryder-accent', '217 70 239'),
+  )
+  await expect(chip).toHaveCSS('background-color', 'rgb(217, 70, 239)')
+})
+
+test('token tables are rendered from the data file, through the real table wrapper', async ({
+  page,
+}) => {
+  await page.goto(PAGE)
+
+  // Both halves matter: the tables exist, and they are wrapped by the same
+  // v0.4.0 component the page documents further down rather than by bespoke
+  // markup written for this page.
+  const tables = page.locator('.ryder-table')
+  expect(await tables.count()).toBeGreaterThanOrEqual(6)
+
+  // A value straight out of data/design-system.json.
+  await expect(page.locator('.ryder-table', { hasText: '--ryder-brand' }).first()).toContainText(
+    '7 89 133',
+  )
+})
+
+test('the form preview is a real ryderForm, wired to the engine', async ({ page }) => {
+  await page.goto(PAGE)
+
+  const form = page.locator('form[x-data="ryderForm"]')
+  await expect(form).toHaveCount(1)
+
+  // Rendered by utils/form-field.html — the label/control pairing and the focus
+  // token are the partial's, not this page's.
+  await expect(form.locator('label[for="email"]')).toBeVisible()
+  await expect(form.locator('#email')).toHaveClass(/outline-ryder-brand/)
+  await expect(form.locator('textarea#message')).toBeVisible()
+  await expect(form.locator('button[type="submit"]')).toBeVisible()
+})
+
+test('component previews come from the theme, not from copied markup', async ({ page }) => {
+  await page.goto(PAGE)
+
+  // taxonomy-cloud, cta-button and alert-wrapper, each called live.
+  expect(await page.locator('.tagcloud-item').count()).toBeGreaterThan(0)
+  expect(await page.locator('a:has(> span.rounded-full)').count()).toBeGreaterThanOrEqual(3)
+  await expect(page.getByText('Yellow — and this yellow is semantic')).toBeVisible()
+})
+
+test('the empty state renders on a section that is genuinely empty', async ({ page }) => {
+  // Before v0.4.0 this code path existed but no exampleSite page reached it, so
+  // nothing built or tested it. The section exists to keep that honest.
+  await page.goto(`${BASE}/docs/empty-section/`)
+
+  await expect(page.locator('.border-dashed')).toBeVisible()
+  await expect(page.getByText('Nothing here yet')).toBeVisible()
+  // The blank grid and the single-page pager it replaced.
+  await expect(page.locator('.pagination')).toHaveCount(0)
+})


### PR DESCRIPTION
**Stacked on #75** — this targets `feat/v0.4.0-design-tokens`, not `main`. GitHub will retarget it to `main` automatically once #75 merges. Merge #75 first, then this, then tag v0.4.0.

PR 1 added the token layer and three components. This documents them, by rendering the theme rather than describing it.

## The page

`exampleSite/content/docs/design-system.md` — Foundations (overview, colour, typography, space/radius/shadow, icons, dark mode, tokens), Components (header/logo/nav, cards, article header & aside, breadcrumb/pagination/taxonomy, alerts, buttons, share, footer), Patterns (shortcodes plus the three v0.4.0 additions). Mirrors the design reference's own outline.

**Every preview is a live call** — `taxonomy-cloud`, `alert-wrapper`, `cta-button`, the new `form-field` partial, the new `table-wrapper`. Where a component *is* the page chrome (header, cards, footer, the aside beside the text) the page says so and points at itself, rather than pasting a copy that can go stale. Each section carries its Hugo usage snippet and its class list — the split that made the reference page useful.

Values come from `exampleSite/data/design-system.json` through two new shortcodes, `swatch` and `token-table`, so a number exists in exactly one place. Both live in `exampleSite/layouts/`, not the theme: they document this theme, they aren't part of it.

## An empty section, so the empty state is real

The empty state shipped in PR 1 sat on a code path no exampleSite page reached, so no build or test rendered it — I needed throwaway content to verify it at the time. `exampleSite/content/docs/empty-section/` is a genuinely empty section, so it's now exercised by every build, linked from the design-system page, and covered by e2e. Its own page explains where it sits among the theme's three answers to "nothing here".

## Tests

The page's premise is that previews can't drift because they *are* the live components. A screenshot cannot verify that — stale hardcoded markup would look identical. So `tests/e2e/designSystem.spec.js` asserts the claim directly: the accent swatch must follow a runtime override of `--ryder-accent`, the token tables must carry values from the data file and use the real table wrapper, the form must be a genuine `ryderForm` wired to the partial's markup, and the empty state must render without a pager.

## Two things worth a look in review

**Swatch chips are painted inline, not with a `bg-ryder-*` class.** Two reasons: they stay live, so overriding a token moves them with the rest of the theme; and a class assembled from data would exist only in `hugo_stats.json`, which is gitignored — so a cold clone's first build would emit CSS without it (CLAUDE.md > Release Maintenance documents the three classes already in that trap; this doesn't add a fourth). `safeCSS` is required on the custom-property name, or Go's contextual autoescaper substitutes `ZgotmplZ` and the chip silently paints nothing.

**`faSwatchbook` was added to `main.js`.** Unlike PR 1, this one needed a genuinely new glyph. The icon audit enforces both directions, so it failed until the page actually used it.

## Discrepancies found against the design reference

Both were the reference over-simplifying; the repo won, per the handoff's rule.

1. **Gutters.** The reference's token list says `px-3 md:px-8 lg:px-12`. The theme actually uses `px-3 py-3 md:px-4` on the header and `px-3 py-5 md:px-4` on the footer — there is no `md:px-8` or `lg:px-12` anywhere. The data file records what the theme does.
2. **Eyebrow tracking.** The reference describes one eyebrow (`tracking-[0.22em]`). There are three in the theme: `0.18em` in aside headings, `0.2em` on article meta and form labels, `0.22em` on the share and footer rails. The page documents all three and notes they're close enough to look like a mistake and far enough apart to be deliberate.

## Also

- `forms.md` gains a "Styling the fields" section pointing at the `form-field` partial, with the honeypot left hand-written and the reason why.
- README links the page, and drops a stale claim that `[params.colors]` repoints the header/footer chrome — corrected in #75's third commit.
- `docs/design-decisions.md` §6 describes `/docs/design-system/` in the present tense. That becomes true when this merges.

## Verification

Production build clean, zero warnings. 14 unit tests, **76 e2e** (up from 71 — five new).

Note: the in-app browser's screenshot capture was returning blank frames during this work and misreporting the viewport, so the visual check was done via DOM geometry, computed styles, and the built HTML rather than images. The e2e assertions above are the durable version of that check.

## Outstanding for the tag

`images/screenshot.png` (1500x1000) and `images/tn.png` (900x600) still need refreshing per CLAUDE.md before v0.4.0 is tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
