### PR TITLE
Fix build aborts on remote fetches in picture and highlight-github (v0.3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to the Ryder Hugo theme are documented in this file.
 
+## Unreleased
+
+- **Fix** — `picture.html` no longer aborts the build on remote images.
+  It read `.Err` on the result of `resources.GetRemote`, a field removed in
+  Hugo v0.141.0 — below the theme's own v0.146.0 floor, so the failure applied
+  to every supported Hugo version. The call now goes through `try`. Only
+  absolute-URL sources were affected, so bundle-resource-only sites never saw
+  it.
+- **Fix** — `highlight-github` degrades to a link instead of killing the
+  build when `api.github.com` is unreachable. Both fetch sites used
+  `with`/`else` around `resources.GetRemote`, which raises a hard template
+  error on a blocked host — so the `else` branch never ran and the build died
+  with a raw internal error. Both now use `try`, warn, and fall back to a link
+  to the file on GitHub. Set `params.highlightGithubStrict = true` to keep the
+  hard failure.
+- **Development** — Both templates raise their in-file minimum Hugo version
+  from 0.125.6 to 0.141.0, the floor for the `try` keyword. The theme already
+  required 0.146.0 in `hugo.toml`.
+
 ## v0.3.1
 
 - **Dependencies** — Update `jsdom` from 29.1.1 to 30.0.1 and the example

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Ryder Hugo theme are documented in this file.
 
-## Unreleased
+## v0.3.2
 
 - **Fix** — `picture.html` no longer aborts the build on remote images.
   It read `.Err` on the result of `resources.GetRemote`, a field removed in

--- a/README.md
+++ b/README.md
@@ -650,6 +650,27 @@ enableGitInfo = true
 | `font-awesome` | Inline Font Awesome icon |
 | `highlight-github` | GitHub-styled syntax highlight block |
 
+#### `highlight-github` and network access
+
+`highlight-github` reads the file through the GitHub API at build time. When
+`api.github.com` is unreachable — a sandboxed CI runner, or an environment that
+routes GitHub traffic through a proxy serving only git operations — the
+shortcode logs a warning and degrades to a plain link to the file on GitHub
+rather than failing the build. The link is rendered even when `showlink=false`,
+since it is the only remaining output.
+
+To treat an unreachable API as a hard build failure instead, set:
+
+```toml
+[params]
+  highlightGithubStrict = true
+```
+
+This is off by default deliberately. Gating the failure on
+`hugo.Environment` would not work: a plain `hugo` build already reports the
+`production` environment, so the strict path would fire in exactly the
+sandboxed CI builds this degradation exists to keep working.
+
 ### Recipe Schema
 
 Set `recipe = true` in front matter to enable Schema.org/Recipe JSON-LD structured data. Ingredients and steps live entirely in front matter:

--- a/exampleSite/data/releases.json
+++ b/exampleSite/data/releases.json
@@ -1,6 +1,11 @@
 {
   "items": [
     {
+      "title": "v0.3.2",
+      "summary": "Remote-fetch build fixes: picture.html drops the removed Resource.Err, highlight-github degrades to a link when the GitHub API is unreachable.",
+      "link": "https://github.com/arts-link/ryder/releases/tag/v0.3.2"
+    },
+    {
       "title": "v0.3.1",
       "summary": "Development dependency and GitHub Actions updates, with tests moved to Node.js 24.",
       "link": "https://github.com/arts-link/ryder/releases/tag/v0.3.1"

--- a/exampleSite/package-lock.json
+++ b/exampleSite/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ryder-example-site",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ryder-example-site",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "@alpinejs/csp": "^3.15.12",

--- a/exampleSite/package.json
+++ b/exampleSite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ryder-example-site",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Example site for the Ryder Hugo theme",
   "author": "Ben Strawbridge",
   "license": "MIT",

--- a/layouts/partials/picture.html
+++ b/layouts/partials/picture.html
@@ -99,7 +99,8 @@ Add this CSS to your site to remove small gaps between adjacent elements:
 {{- $partialName := "picture" }}
 
 {{- /* Verify minimum required version. */}}
-{{- $minHugoVersion := "0.125.6" }}
+{{- /* 0.141.0 is the floor for the `try` keyword used to fetch remote images. */}}
+{{- $minHugoVersion := "0.141.0" }}
 {{- if lt hugo.Version $minHugoVersion }}
   {{- errorf "The %q partial requires Hugo v%s or later." $partialName $minHugoVersion }}
 {{- end }}
@@ -330,15 +331,23 @@ Add this CSS to your site to remove small gaps between adjacent elements:
   {{- /* Get image resource. */}}
   {{- $r := "" }}
   {{- if $u.IsAbs }}
-    {{- with resources.GetRemote $u.String }}
+    {{- /*
+      `try` is required here: an unreachable host makes resources.GetRemote
+      raise a hard template error rather than return nothing, so a bare
+      `with`/`else` never reaches its `else` branch. Resource.Err was removed
+      in Hugo v0.141.0 and replaced by `try`.
+      @ref https://gohugo.io/functions/go-template/try/
+    */}}
+    {{- with try (resources.GetRemote $u.String) }}
       {{- with .Err }}
         {{- errorf "%s. See %s" . $.contentPath }}
-      {{- else }}
+      {{- else with .Value }}
         {{- /* Destination is a remote resource. */}}
         {{- $r = . }}
+      {{- else }}
+        {{- /* A 404 yields no error and no value. */}}
+        {{- errorf $msg }}
       {{- end }}
-    {{- else }}
-      {{- errorf $msg }}
     {{- end }}
   {{- else }}
     {{- with .page.Resources.Get (strings.TrimPrefix "./" $u.Path) }}

--- a/layouts/shortcodes/highlight-github.html
+++ b/layouts/shortcodes/highlight-github.html
@@ -54,7 +54,8 @@ Renders highlighted code from a file in a GitHub repository.
 */}}
 
 {{- /* Verify minimum required version. */}}
-{{- $minHugoVersion := "0.125.6" }}
+{{- /* 0.141.0 is the floor for the `try` keyword used to call the GitHub API. */}}
+{{- $minHugoVersion := "0.141.0" }}
 {{- if lt hugo.Version $minHugoVersion }}
   {{- errorf "The %s shortcode requires Hugo v%s or later." .Name $minHugoVersion }}
 {{- end }}
@@ -74,27 +75,62 @@ Renders highlighted code from a file in a GitHub repository.
 
 {{- if and $owner $repo $path }}
 
+  {{- /*
+    Both calls below go through `try`. An unreachable or blocked api.github.com
+    makes resources.GetRemote raise a hard template error rather than return
+    nothing, so a bare `with`/`else` never reaches its `else` branch and the
+    build dies with a raw internal error. This matters in sandboxed CI, and
+    wherever GitHub traffic is routed through a proxy that serves only git
+    operations. When a call fails we warn and degrade to a link to the file on
+    GitHub; set `params.highlightGithubStrict` to fail the build instead.
+    @ref https://gohugo.io/functions/go-template/try/
+  */}}
+  {{- $ok := true }}
+  {{- $strict := site.Params.highlightGithubStrict | default false }}
+
   {{- /* Get branch. */}}
   {{- $apiEndPoint := urls.JoinPath $apiBase "repos" $owner $repo }}
-  {{- $data := "" }}
-  {{- with resources.GetRemote $apiEndPoint }}
-    {{- $data = . | transform.Unmarshal }}
-  {{- else }}
-    {{- errorf "Unable to get remote resource %q" $apiEndPoint }}
+  {{- $data := dict }}
+  {{- with try (resources.GetRemote $apiEndPoint) }}
+    {{- with .Err }}
+      {{- $ok = false }}
+      {{- warnf "The %q shortcode was unable to get %q: %s. See %s" $.Name $apiEndPoint . $.Position }}
+    {{- else with .Value }}
+      {{- $data = . | transform.Unmarshal }}
+    {{- else }}
+      {{- /* A 404 yields no error and no value. */}}
+      {{- $ok = false }}
+      {{- warnf "The %q shortcode was unable to get %q. See %s" $.Name $apiEndPoint $.Position }}
+    {{- end }}
   {{- end }}
-  {{- $branch := or (.Get "branch") $data.default_branch }}
+  {{- $branch := or (.Get "branch") $data.default_branch "HEAD" }}
 
   {{- /* Get content. */}}
-  {{- $apiEndPoint := urls.JoinPath $apiBase "repos" $owner $repo "contents" $path }}
-  {{- $query := querify "ref" $branch }}
-  {{- $apiEndPoint = printf "%s?%s" $apiEndPoint $query }}
-  {{- $data := "" }}
-  {{- with resources.GetRemote $apiEndPoint }}
-    {{- $data = . | transform.Unmarshal }}
-  {{- else }}
-    {{- errorf "Unable to get remote resource %q" $apiEndPoint }}
+  {{- $content := "" }}
+  {{- if $ok }}
+    {{- $apiEndPoint = urls.JoinPath $apiBase "repos" $owner $repo "contents" $path }}
+    {{- $query := querify "ref" $branch }}
+    {{- $apiEndPoint = printf "%s?%s" $apiEndPoint $query }}
+    {{- $data = dict }}
+    {{- with try (resources.GetRemote $apiEndPoint) }}
+      {{- with .Err }}
+        {{- $ok = false }}
+        {{- warnf "The %q shortcode was unable to get %q: %s. See %s" $.Name $apiEndPoint . $.Position }}
+      {{- else with .Value }}
+        {{- $data = . | transform.Unmarshal }}
+      {{- else }}
+        {{- $ok = false }}
+        {{- warnf "The %q shortcode was unable to get %q. See %s" $.Name $apiEndPoint $.Position }}
+      {{- end }}
+    {{- end }}
+    {{- with $data.content }}
+      {{- $content = . | base64Decode }}
+    {{- end }}
   {{- end }}
-  {{- $content := ($data.content | base64Decode) }}
+
+  {{- if and (not $ok) $strict }}
+    {{- errorf "The %q shortcode was unable to get %q. See %s" .Name $apiEndPoint .Position }}
+  {{- end }}
 
   {{- /* Get subset of content if lines parameter is set. */}}
   {{- $lineNoStart := 1 }}
@@ -103,9 +139,12 @@ Renders highlighted code from a file in a GitHub repository.
     {{- if findRE `^\d+-\d+` . }}
       {{- $lineNoStart = index (split . "-") 0 | int }}
       {{- $lineNoEnd = index (split . "-") 1 | int }}
-      {{- $contentLines := split $content "\n" }}
-      {{- $contentLines = $contentLines | after (sub $lineNoStart 1) | first (add 1 (sub $lineNoEnd $lineNoStart ))}}
-      {{- $content = add (delimit $contentLines "\n") "\n" }}
+      {{- /* Parsed even when degraded, so the fallback link keeps its anchor. */}}
+      {{- if $ok }}
+        {{- $contentLines := split $content "\n" }}
+        {{- $contentLines = $contentLines | after (sub $lineNoStart 1) | first (add 1 (sub $lineNoEnd $lineNoStart ))}}
+        {{- $content = add (delimit $contentLines "\n") "\n" }}
+      {{- end }}
     {{- else }}
       {{- errorf "The %q shortcode requires the lines parameter to have the format n-n. See %s" $.Name $.Position }}
     {{- end }}
@@ -141,8 +180,10 @@ Renders highlighted code from a file in a GitHub repository.
   {{- end }}
 
   {{- /* Determine language and highlight the code. */}}
-  {{- $lang := or (.Get "lang") (path.Ext $path | strings.TrimPrefix "." ) "text" }}
-  {{- highlight $content $lang $opts }}
+  {{- if $ok }}
+    {{- $lang := or (.Get "lang") (path.Ext $path | strings.TrimPrefix "." ) "text" }}
+    {{- highlight $content $lang $opts }}
+  {{- end }}
 
   {{- /* Render link to blob. */}}
   {{- $temp := .Get "showlink" }}
@@ -151,7 +192,8 @@ Renders highlighted code from a file in a GitHub repository.
   {{- else if in (slice "true" true 1) $temp }}
     {{- $showLink = true }}
   {{- end }}
-  {{- if $showLink }}
+  {{- /* When degraded the link is the only output, so render it regardless. */}}
+  {{- if or $showLink (not $ok) }}
     {{- $href := urls.JoinPath "https://" $tld $owner $repo "blob" $branch $path }}
     {{- if $lineNoEnd }}
       {{- $href = printf "%s#%s" $href (printf "L%d-L%d" $lineNoStart $lineNoEnd) }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ryder",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ryder",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "engines": {
         "node": "^22.22.2 || ^24.15.0 || >=26.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ryder",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A barebones Hugo theme built with TailwindCSS and Alpine.js",
   "author": "Ben Strawbridge",
   "license": "MIT",

--- a/theme.toml
+++ b/theme.toml
@@ -1,5 +1,5 @@
 name = 'ryder'
-version = 'v0.3.1'
+version = 'v0.3.2'
 license = 'MIT'
 licenselink = 'https://github.com/arts-link/ryder/LICENSE'
 description = 'A fast, accessible Hugo theme built with TailwindCSS and Alpine.js. Ships with dark mode, responsive navigation with dropdowns, OpenGraph image generation, Leaflet maps, photo galleries, recipe schema, share buttons, customizable headers and footers, and a Content Security Policy meta tag. Built for blogs, portfolios, and small business sites. Easily extended without modifying theme files.'


### PR DESCRIPTION
Fixes #77. Fixes #78.

Two templates aborted the build on remote fetches. Both now go through `try`.

## `picture.html` (#77)

It read `.Err` on the result of `resources.GetRemote`. That field was removed in Hugo **v0.141.0** — below this theme's own `v0.146.0` floor in `hugo.toml` — so the failure applied to every Hugo version the theme claims to support, not just the latest:

```
can't evaluate field Err in type resource.Resource:
Resource.Err was removed in Hugo v0.141.0 and replaced with a new try keyword
```

Only absolute-URL sources reached that branch, so bundle-resource-only sites never saw it.

The fix uses three branches, not two. `try` returns a wrapper: `.Err` on failure, `.Value` on success — and a **404 returns neither**, which a two-branch fix would silently treat as success. `picture` keeps its documented contract of failing the build on an unresolvable destination; what changes is that it now fails with the theme's own message instead of a raw internal error.

## `highlight-github` (#78)

Both API calls used `{{ with resources.GetRemote }}…{{ else }}{{ errorf }}{{ end }}`, which failed two ways:

1. An unreachable host makes `resources.GetRemote` raise a hard template error rather than return nothing — so the `else` branch **never ran** and the build died with a raw internal error.
2. Where `else` was reachable (a 404), `errorf` killed the build over one unreachable API call.

Both now use `try`, warn, and degrade to a link to the file on GitHub. Two details worth flagging in review:

- The link renders even with `showlink=false`. Degraded, it's the only output, so honoring the flag would emit a silently empty block.
- The `lines` parameter is still parsed while degraded, so the fallback link keeps its `#L55-L73` anchor.

This bites in sandboxed CI and wherever GitHub traffic routes through a proxy serving only git operations — the GitHub API then returns 403 regardless of allowlisting.

### One deliberate departure from the issue

#78 suggested optionally keeping the hard failure when `hugo.Environment` is `production`. I did **not** wire it that way: a plain `hugo` build already reports the `production` environment — only `hugo server` is `development` — so that gate would fire in exactly the sandboxed CI builds this degradation exists to rescue.

It's an opt-in site param instead, off by default:

```toml
[params]
  highlightGithubStrict = true
```

## Verification

Run against `hugo v0.164.0+extended`, not assumed. `api.github.com` is genuinely blocked in this environment, which made the failure case free to test; a local stand-in server covered the success paths.

| Case | Before | After |
|---|---|---|
| Remote image | build abort | fetches, resizes, emits webp+jpeg sources |
| `highlight-github` success | — | renders lines 55–73, resolves `default_branch`, correct anchor |
| Blocked host (real) | build abort | warns, renders link |
| 404 (no `.Err`, no `.Value`) | build abort | warns, degrades — the branch a 2-branch fix misses |
| Strict mode | — | fails the build as intended |

## ⚠️ Merging this publishes a release

Cut as **v0.3.2**, per semver — bug fixes only, no behavior change on the success path.

The release workflow fires only on a push to `main` touching `theme.toml` and reads the tag from its `version` line, so **merging auto-tags `v0.3.2` and publishes a non-prerelease GitHub release** (no `-suffix`, so it takes the "Latest release" badge).

The body comes from the `## v0.3.2` changelog section. That section was originally headed `## Unreleased`, which would have silently broken: the workflow matches `## <tag>` exactly, so the notes would have fallen back to auto-generated ones. Retitled, and I ran the workflow's own `awk` extraction against the file to confirm it matches and bounds correctly at the next heading.

Version carried through `package.json`, both lockfiles, `exampleSite/package.json`, and `exampleSite/data/releases.json` (which drives the demo releases page), matching how v0.3.1 shipped.

**Hold or drop commit `664502a` if you'd rather review the tag separately** — the version bump is isolated there, and the fix commit `af57241` merges without releasing anything.

## Notes for the reviewer

- **No tests added.** `exampleSite` doesn't use `highlight-github`, so there's no existing harness these would slot into, and the e2e suite can't run here (below). Happy to build that out as a follow-up.
- **Pre-existing, unrelated:** `postcss-cli` is not in `package.json`, so `hugo --source exampleSite` fails with `binary with name "postcss" not found in PATH`. I confirmed this reproduces identically on unmodified `main` before attributing it — but it does mean the Playwright e2e suite (which boots `hugo server`) couldn't run here. The vitest unit suite passes 14/14. Probably worth its own issue if CI installs it out-of-band.
- Once this lands, the benstrawbridge.com full-file `highlight-github` override should be deletable — the theme now does what it was doing.