### PR TITLE
v0.4.0 (PR 3): link footer taxonomy headings to their taxonomy root page

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Named after a late Rhodesian Ridgeback/Mastiff companion.
 - **One accent instead of six** — the tag cloud's yellow border and the CTA button's fuchsia ring both move to the theme accent (rose). `params.colors.legacyAccents = true` restores them.
 - **Three new components** — a themed [form field](#form-fields) partial for the existing `ryderForm` engine, a `table-wrapper` shortcode that keeps wide tables from pushing the page sideways, and an empty state on list pages that no longer renders a blank page with a dead pager.
 - **A design-system page** — [arts-link.github.io/ryder/docs/design-system/](https://arts-link.github.io/ryder/docs/design-system/) documents the tokens, type scale, spacing, and every component, rendered by the live theme rather than screenshots of it.
+- **Footer taxonomy headings are links** — each group heading now points at its taxonomy root page (`/tags/`, `/categories/`), with a dotted underline so it reads as one. See [Footer Taxonomy Lists](#footer-taxonomy-lists).
 
 Sites upgrading from v0.3.x should read the [v0.4.0 migration guide](docs/migration/v0.4.0.md) — the accent change is the only thing that alters an existing site, and it is one config flag to undo. The reasoning behind the system is recorded in [docs/design-decisions.md](docs/design-decisions.md).
 
@@ -323,6 +324,15 @@ which reuse the same partial.
   title = "Categories"
   minCount = 1
 ```
+
+By default the footer shows **no** taxonomy lists — `params.footer.taxonomies`
+is opt-in. `minCount` hides terms with fewer than that many pages, so a footer
+cloud doesn't fill with one-off tags.
+
+Each group's heading links to that taxonomy's own root page (`/tags/`,
+`/categories/`) and carries a dotted underline to say so. The href resolves
+through `site.GetPage`, so if a site disables the taxonomy kind or renames its
+path the heading falls back to plain text rather than linking to a 404.
 
 ### Social Links
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -574,6 +574,27 @@
     @apply flex flex-wrap gap-x-3 gap-y-2 text-sm text-neutral-100/85;
   }
 
+  /* The taxonomy group heading, when it links to that taxonomy's root page.
+     The footer's own idiom is underline-on-hover (see .footer-taxonomy-link
+     below), but a heading gives no other signal that it is clickable — so this
+     one carries a dotted underline at rest and firms up on hover, rather than
+     appearing to be a link only once the pointer is already on it. */
+  .footer-section-title-link {
+    @apply inline-flex items-center gap-1.5 rounded-sm;
+    @apply underline decoration-dotted decoration-neutral-100/30 underline-offset-4;
+    @apply transition-colors duration-150 ease-in-out;
+    @apply hover:text-white hover:decoration-neutral-100/80;
+    @apply focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60;
+  }
+
+  .footer-section-title-icon {
+    @apply text-[8px] opacity-60;
+  }
+
+  .footer-section-title-link:hover .footer-section-title-icon {
+    @apply opacity-100;
+  }
+
   .footer-taxonomy-link {
     @apply inline-flex items-start gap-1 break-words rounded-sm;
     @apply hover:text-white hover:underline;

--- a/docs/migration/v0.4.0.md
+++ b/docs/migration/v0.4.0.md
@@ -110,7 +110,17 @@ Three additions, all opt-in:
   with a dead pager. Strings come from `i18n/` (`emptyListTitle`,
   `emptyListBody`); override them there if you want different words.
 
-## 4. Icons
+## 4. Footer taxonomy headings are now links
+
+If you configure `[[params.footer.taxonomies]]`, each group's heading ("Top
+Tags", "Categories") now links to that taxonomy's root page and carries a
+dotted underline so it reads as a link. Previously it was plain text.
+
+Nothing to do, and nothing to configure. The href resolves through
+`site.GetPage`, so if your site disables the taxonomy kind or renames its path,
+the heading stays plain text rather than linking to a 404.
+
+## 5. Icons
 
 No action needed. `fa-signs-post` and `fa-circle-check`, used by the empty
 state, were already in the theme's tree-shaken Font Awesome set.

--- a/exampleSite/content/docs/design-system.md
+++ b/exampleSite/content/docs/design-system.md
@@ -312,6 +312,17 @@ their keep, since a hex would break those modifiers.
 meta rail. Its background falls back to `headerBackgroundFrameOuter` unless
 `twClasses.footerBackground` is set.
 
+Taxonomy group headings link to that taxonomy's root page. Scroll down and look
+at "Top Tags" — it is the one place in the footer where a link is not already
+shaped like one, so it carries a dotted underline at rest
+(`decoration-dotted decoration-neutral-100/30 underline-offset-4`) that firms to
+solid on hover, rather than relying on the footer's usual underline-on-hover
+idiom that only appears once you are already pointing at it.
+
+The href resolves through `site.GetPage` rather than string concatenation, so a
+site that disables the taxonomy kind or renames its path gets a plain heading
+instead of a link to a 404.
+
 ---
 
 # Patterns

--- a/layouts/partials/utils/taxonomy-string.html
+++ b/layouts/partials/utils/taxonomy-string.html
@@ -9,8 +9,24 @@
     {{- $minCount := .minCount | default 1 }}
     {{- $baseURL := $.Site.BaseURL }}
 
+    {{- /* The heading links to the taxonomy's own root page (/tags/, /categories/)
+           when Hugo generated one. site.GetPage rather than a hand-built URL:
+           a site can disable the taxonomy kind in [outputs] or rename its path,
+           and a string-concatenated href would then point at a 404. When there
+           is no such page the heading stays plain text — a heading that looks
+           like a link and isn't is worse than one that doesn't. */ -}}
+    {{- $taxonomyPage := site.GetPage $taxonomy }}
     <div class="footer-taxonomy-group">
-      <h4 class="footer-section-title">{{ $title }}</h4>
+      <h4 class="footer-section-title">
+        {{- with $taxonomyPage -}}
+        <a href="{{ .RelPermalink }}" class="footer-section-title-link">
+          <span>{{ $title }}</span>
+          <i class="fa-solid fa-angles-right footer-section-title-icon" aria-hidden="true"></i>
+        </a>
+        {{- else -}}
+        {{ $title }}
+        {{- end -}}
+      </h4>
       <div class="footer-taxonomy-links">
       {{- range $name, $taxonomyPage := (index $.Site.Taxonomies $taxonomy) }}
         {{- $tagCount := len $taxonomyPage.Pages }}

--- a/tests/e2e/footerTaxonomyLinks.spec.js
+++ b/tests/e2e/footerTaxonomyLinks.spec.js
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test'
+
+const BASE = '/ryder'
+
+// The footer's taxonomy groups list individual terms, but the group heading
+// ("Top Tags", "Categories") was plain text — the one place in the footer that
+// named a taxonomy without offering a way to reach it. It now links to that
+// taxonomy's root page.
+//
+// The heading resolves its href through site.GetPage rather than string
+// concatenation, so these assertions care about two things: that the link
+// exists and points somewhere Hugo actually built, and that it reads as a link
+// before you hover it.
+
+test('footer taxonomy headings link to their taxonomy root page', async ({ page }) => {
+  await page.goto(`${BASE}/`)
+
+  const headings = page.locator('.footer-section-title .footer-section-title-link')
+  expect(await headings.count()).toBeGreaterThan(0)
+
+  // exampleSite configures tags and categories under [params.footer.taxonomies].
+  const tags = page.locator('.footer-section-title-link', { hasText: 'Top Tags' })
+  await expect(tags).toHaveAttribute('href', `${BASE}/tags/`)
+
+  const categories = page.locator('.footer-section-title-link', { hasText: 'Categories' })
+  await expect(categories).toHaveAttribute('href', `${BASE}/categories/`)
+})
+
+test('the heading link actually resolves', async ({ page }) => {
+  // A heading that looks like a link and 404s is worse than plain text, and a
+  // hand-built href would do exactly that if a site renamed the taxonomy path.
+  await page.goto(`${BASE}/`)
+  await page.locator('.footer-section-title-link', { hasText: 'Top Tags' }).click()
+
+  await expect(page).toHaveURL(new RegExp(`${BASE}/tags/$`))
+  await expect(page.locator('.tagcloud-item').first()).toBeVisible()
+})
+
+test('the heading is visibly a link at rest, not only on hover', async ({ page }) => {
+  await page.goto(`${BASE}/`)
+  const link = page.locator('.footer-section-title-link', { hasText: 'Top Tags' })
+
+  // The footer's usual idiom is underline-on-hover, which is fine for something
+  // already shaped like a link. A heading needs the affordance up front.
+  await expect(link).toHaveCSS('text-decoration-line', 'underline')
+  await expect(link).toHaveCSS('text-decoration-style', 'dotted')
+})


### PR DESCRIPTION
**Stacked on #76**, which is stacked on #75. Merge order: #75 → #76 → this → tag v0.4.0. Each retargets automatically as the one below it merges.

Small add-on to the v0.4.0 release, **no version bump of its own**.

## What

The footer's taxonomy groups list individual terms under a heading — "Top Tags", "Categories" — that was plain text. It was the one place in the footer that named a taxonomy without offering any way to reach it.

The heading now links to that taxonomy's root page (`/tags/`, `/categories/`).

## Two decisions worth reviewing

**The href resolves through `site.GetPage`, not string concatenation.** The sibling term links in the same partial build their URLs as `baseURL + taxonomy + name`. That works for terms, but for the root page it would break for any site that disables the taxonomy kind in `[outputs]` or renames its path — the heading would link to a 404. `site.GetPage` returns nothing in that case, and the heading falls back to plain text. A heading that looks like a link and isn't is worse than one that doesn't.

**The treatment is a dotted underline at rest, not underline-on-hover.** The footer's existing idiom (`.footer-taxonomy-link`) is `hover:underline`, which is fine for something already shaped like a link. A heading gives no other signal that it's clickable, so hover-only would mean the affordance only appears once you're already pointing at it. This carries `decoration-dotted decoration-neutral-100/30 underline-offset-4` at rest, firming to solid white on hover, plus a small chevron that goes from 60% to full opacity.

`fa-angles-right` was already in the tree-shaken icon set, so the JS bundle is unchanged and the icon audit needed nothing.

## Tests

`tests/e2e/footerTaxonomyLinks.spec.js` — three assertions: the headings point where Hugo actually built, following one lands on the tag cloud, and the underline is present at rest rather than only on hover.

## Docs

README's Footer Taxonomy Lists section, the design-system page's Footer section, the v0.4.0 What's New list, and a short section in the migration guide (nothing to do, but the appearance changes for anyone using footer taxonomies).

## Verification

Production build clean, zero warnings. 14 unit tests, **79 e2e** (up from 76 — three new).

## A note on how this branch was built

I initially cut this branch from `a124253` rather than from #76's tip, so the first round of work and verification ran against the pre-v0.4.0 tree. Caught it when a doc edit failed against a file that doesn't exist there. The work was moved onto the correct base and fully re-verified — the numbers above are from the corrected branch. Flagging it because it's the second time this session the working tree moved to an unexpected commit on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
